### PR TITLE
style: crm modal bottom margin

### DIFF
--- a/frontend/packages/web/src/assets/style/global.less
+++ b/frontend/packages/web/src/assets/style/global.less
@@ -131,13 +131,12 @@ body {
 // model表单
 .crm-form-modal {
   .n-dialog__content {
-    margin-bottom: 0;
+    margin-bottom: 16px;
   }
   .n-form-item:last-of-type {
     .n-form-item-feedback-wrapper {
       overflow: hidden;
-      height: 16px;
-      min-height: 16px;
+      min-height: 0;
       line-height: 1;
     }
   }

--- a/frontend/packages/web/src/components/business/crm-batch-edit-modal/index.vue
+++ b/frontend/packages/web/src/components/business/crm-batch-edit-modal/index.vue
@@ -3,7 +3,6 @@
     v-model:show="visible"
     :title="t('common.batchEdit')"
     siz="small"
-    class="crm-form-modal"
     :positive-text="t('common.update')"
     :negative-text="t('common.cancel')"
     :ok-loading="loading"

--- a/frontend/packages/web/src/components/business/crm-move-modal/index.vue
+++ b/frontend/packages/web/src/components/business/crm-move-modal/index.vue
@@ -7,7 +7,6 @@
     :mask-closable="false"
     :type="props.type"
     :ok-button-props="{ disabled: enableReason ? !form.reason : false, type: props.type || 'primary' }"
-    class="crm-form-modal"
     :positive-text="t('common.confirmMoveIn')"
     :ok-loading="loading"
     @confirm="handleConfirm"

--- a/frontend/packages/web/src/components/business/crm-select-user-drawer/index.vue
+++ b/frontend/packages/web/src/components/business/crm-select-user-drawer/index.vue
@@ -34,11 +34,22 @@
         @update-value="handleUpdateValue"
       />
     </div>
+    <template #footer>
+      <div class="flex w-full items-center gap-[12px]">
+        <n-button :disabled="addMembers.length === 0" :loading="props.loading" type="primary" @click="handleAddConfirm">
+          {{ t(props.okText || 'common.add') }}
+        </n-button>
+        <n-button secondary @click="handleCancelAdd">
+          {{ t('common.cancel') }}
+        </n-button>
+      </div>
+    </template>
   </CrmDrawer>
 </template>
 
 <script setup lang="ts">
   import {
+    NButton,
     NSkeleton,
     NTabPane,
     NTabs,
@@ -115,6 +126,7 @@
   const selectedNodes = ref<SelectedUsersItem[]>([]);
 
   function handleCancelAdd() {
+    visible.value = false;
     addMembers.value = [];
     selectedNodes.value = [];
     addMemberType.value = (props.memberTypes?.[0]?.value as MemberSelectTypeEnum) || MemberSelectTypeEnum.ORG;

--- a/frontend/packages/web/src/components/business/crm-transfer-modal/index.vue
+++ b/frontend/packages/web/src/components/business/crm-transfer-modal/index.vue
@@ -5,7 +5,6 @@
     :title="title"
     :ok-loading="loading"
     :positive-text="props.positiveText || t('common.transfer')"
-    class="crm-form-modal"
     @confirm="confirmHandler"
     @cancel="closeHandler"
   >

--- a/frontend/packages/web/src/components/pure/crm-modal/index.vue
+++ b/frontend/packages/web/src/components/pure/crm-modal/index.vue
@@ -4,7 +4,7 @@
     v-model:show="showModal"
     :show-icon="props.showIcon"
     :preset="props.preset"
-    :class="`crm-modal crm-modal-${props.size || 'medium'}`"
+    :class="`crm-modal crm-form-modal crm-modal-${props.size || 'medium'}`"
     @positive-click="positiveClick"
     @negative-click="negativeClick"
     @after-leave="emit('cancel')"

--- a/frontend/packages/web/src/views/customer/components/mergeAccountModal.vue
+++ b/frontend/packages/web/src/views/customer/components/mergeAccountModal.vue
@@ -4,7 +4,6 @@
     :title="t('customer.mergeAccount')"
     :ok-loading="loading"
     :positive-text="t('customer.merge')"
-    class="crm-form-modal"
     @confirm="confirmHandler"
     @cancel="cancelHandler"
   >

--- a/frontend/packages/web/src/views/system/business/components/apiKey.vue
+++ b/frontend/packages/web/src/views/system/business/components/apiKey.vue
@@ -148,7 +148,6 @@
       v-model:show="timeModalVisible"
       :title="t('system.personal.setValidTime')"
       :positive-text="t('common.save')"
-      class="crm-form-modal"
       @confirm="handleTimeConfirm"
       @cancel="handleTimeClose"
     >

--- a/frontend/packages/web/src/views/system/business/components/editIntegrationModal.vue
+++ b/frontend/packages/web/src/views/system/business/components/editIntegrationModal.vue
@@ -2,7 +2,6 @@
   <CrmModal
     v-model:show="showModal"
     :title="t('system.business.configType', { type: props.title })"
-    class="crm-form-modal"
     :mask-closable="false"
   >
     <n-form

--- a/frontend/packages/web/src/views/system/business/components/editPasswordModal.vue
+++ b/frontend/packages/web/src/views/system/business/components/editPasswordModal.vue
@@ -1,11 +1,5 @@
 <template>
-  <CrmModal
-    v-model:show="showModal"
-    class="crm-form-modal"
-    size="small"
-    :title="t('system.personal.changePassword')"
-    @cancel="cancel"
-  >
+  <CrmModal v-model:show="showModal" size="small" :title="t('system.personal.changePassword')" @cancel="cancel">
     <n-form
       ref="formRef"
       :model="form"

--- a/frontend/packages/web/src/views/system/business/components/editPersonalInfoModal.vue
+++ b/frontend/packages/web/src/views/system/business/components/editPersonalInfoModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <CrmModal v-model:show="showModal" class="crm-form-modal" size="small" :title="t('common.update')" @cancel="cancel">
+  <CrmModal v-model:show="showModal" size="small" :title="t('common.update')" @cancel="cancel">
     <n-form
       ref="formRef"
       :model="form"

--- a/frontend/packages/web/src/views/system/message/components/addNotifyModal.vue
+++ b/frontend/packages/web/src/views/system/message/components/addNotifyModal.vue
@@ -3,7 +3,6 @@
     v-model:show="showModal"
     :title="form.id ? t('system.message.updateAnnouncement') : t('system.message.newAnnouncement')"
     :ok-loading="loading"
-    class="crm-form-modal"
     @confirm="handleConfirm"
     @cancel="handleCancel"
   >

--- a/frontend/packages/web/src/views/system/org/components/setDepHead.vue
+++ b/frontend/packages/web/src/views/system/org/components/setDepHead.vue
@@ -4,7 +4,6 @@
     size="small"
     :title="t('org.setDepartmentHead')"
     :ok-loading="loading"
-    class="crm-form-modal"
     @confirm="confirmHandler"
     @cancel="closeHandler"
   >


### PR DESCRIPTION
【【通用-弹窗】内容区与底部按钮直接的间距为16px(组件统一更改)】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001063315
【【智能体-添加智能体】可查看成员的抽屉下的按钮位置，需要左右互换】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001063313