### PR TITLE
fix: 修复删除客户时误删所有客户标签的问题

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/common/service/BaseResourceFieldService.java
+++ b/backend/crm/src/main/java/cn/cordys/common/service/BaseResourceFieldService.java
@@ -667,7 +667,7 @@ public abstract class BaseResourceFieldService<T extends BaseResourceField, V ex
         getResourceFieldMapper().deleteByLambda(wrapper);
 
         LambdaQueryWrapper<V> blobWrapper = new LambdaQueryWrapper<>();
-        wrapper.in(BaseResourceField::getResourceId, resourceIds);
+        blobWrapper.in(BaseResourceField::getResourceId, resourceIds);
         getResourceFieldBlobMapper().deleteByLambda(blobWrapper);
     }
 


### PR DESCRIPTION
第 670 行变量名错误，导致 blobWrapper 查询条件为空，
删除时相当于执行了 DELETE FROM customer_field_blob 没加 WHERE 条件。

已修改为正确的 blobWrapper.in() 调用。

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.