### PR TITLE
fix: tooltip scroll hover

### DIFF
--- a/frontend/packages/web/src/assets/style/naive-reset.less
+++ b/frontend/packages/web/src/assets/style/naive-reset.less
@@ -162,6 +162,9 @@
     @apply overflow-y-auto break-all;
 
     max-height: 30vh;
+    &:hover {
+      .crm-scroll-bar();
+    }
     .crm-scroll-bar();
   }
 }


### PR DESCRIPTION
【【产品】产品详情页-超过20字符的所有字段内容hover显示全部时，若需要上下滑动查看内容，滚动条未默认显示】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001064865