### PR TITLE
fix: message expire config

### DIFF
--- a/frontend/packages/web/src/views/system/message/components/expirationSettingDrawer.vue
+++ b/frontend/packages/web/src/views/system/message/components/expirationSettingDrawer.vue
@@ -49,6 +49,16 @@
             </n-checkbox>
             <CrmInputNumber v-model:value="form.ownerLevel" max="10000" :precision="0" class="w-[80px]" :min="0" />
             {{ t('system.message.noticeOfDepartmentHead') }}
+            <n-tooltip placement="bottom">
+              <template #trigger>
+                <CrmIcon
+                  type="iconicon_help_circle"
+                  :size="16"
+                  class="cursor-pointer text-[var(--text-n4)] hover:text-[var(--primary-1)]"
+                />
+              </template>
+              {{ t('system.message.departmentHeadTooltip') }}
+            </n-tooltip>
           </div>
           <div class="flex flex-nowrap items-start gap-[8px]">
             <n-checkbox v-model:checked="form.roleEnable" class="mt-[4px]">
@@ -75,7 +85,7 @@
 
 <script setup lang="ts">
   import { ref } from 'vue';
-  import { FormInst, NCheckbox, NForm, NFormItem, NScrollbar, useMessage } from 'naive-ui';
+  import { FormInst, NCheckbox, NForm, NFormItem, NScrollbar, NTooltip, useMessage } from 'naive-ui';
   import { cloneDeep } from 'lodash-es';
 
   import { FieldTypeEnum } from '@lib/shared/enums/formDesignEnum';
@@ -198,8 +208,8 @@
                 };
               })
             : [],
-          userIds: form.value.userIds.map((e: any) => e.id),
-          roleIds: form.value.roleIds.map((e: any) => e.id),
+          userIds: form.value.userIds?.map((e: any) => e.id),
+          roleIds: form.value.roleIds?.map((e: any) => e.id),
         },
         ...props.detail?.messageTaskDetailDTOList.find((e) => e.event === props.detail?.event),
         module: props.detail?.module ?? '',

--- a/frontend/packages/web/src/views/system/message/locale/en-US.ts
+++ b/frontend/packages/web/src/views/system/message/locale/en-US.ts
@@ -54,4 +54,5 @@ export default {
   'system.message.maxLimit': 'Maximum number of {count} items',
   'system.message.toHeadAbove': 'To the head and above',
   'system.message.noticeOfDepartmentHead': 'Notice from the head of the level department',
+  'system.message.departmentHeadTooltip': '0 represents the direct superior',
 };

--- a/frontend/packages/web/src/views/system/message/locale/zh-CN.ts
+++ b/frontend/packages/web/src/views/system/message/locale/zh-CN.ts
@@ -53,4 +53,5 @@ export default {
   'system.message.maxLimit': '最多可添加 {count} 条',
   'system.message.toHeadAbove': '向负责人及以上',
   'system.message.noticeOfDepartmentHead': '级部门负责人通知',
+  'system.message.departmentHeadTooltip': '0 代表直属上级',
 };


### PR DESCRIPTION
【【消息设置】合同管理-合同即将到期和回款计划即将到期中添加到期提醒后无法提交】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065349

【【消息设置】合同/报价/回款计划配置没有添加提示信息】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065354