### PR TITLE
fix: message expire config role

### DIFF
--- a/frontend/packages/web/src/views/system/message/components/expirationSettingDrawer.vue
+++ b/frontend/packages/web/src/views/system/message/components/expirationSettingDrawer.vue
@@ -74,7 +74,12 @@
               path="roleIds"
               class="flex-1"
             >
-              <CrmUserTagSelector v-model:selected-list="form.roleIds" class="flex-1" :member-types="memberTypes" />
+              <CrmUserTagSelector
+                v-model:selected-list="form.roleIds"
+                :disabledList="form.roleIds"
+                class="flex-1"
+                :member-types="memberTypes"
+              />
             </n-form-item>
           </div>
         </div>


### PR DESCRIPTION
【【消息设置】报价到期-点击齿轮-已选择角色，再次选择时无高亮，全选仍可选择已经选择过的角色】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065378