### PR TITLE
fix: message config default remove

### DIFF
--- a/frontend/packages/web/src/components/business/crm-batch-form/index.vue
+++ b/frontend/packages/web/src/components/business/crm-batch-form/index.vue
@@ -271,12 +271,14 @@
       move?: (evt: any) => boolean;
       disabledAddTooltip?: string;
       maxLimitLength?: number;
+      needInitFormRow?: boolean; // 是否需要初始化一行数据
     }>(),
     {
       maxHeight: '100%',
       disabledAdd: false,
       showAllOr: false,
       draggable: false,
+      needInitFormRow: true,
     }
   );
 
@@ -323,12 +325,13 @@
         formItem[e.path] = valueIsArray(e) ? [] : null;
       }
     });
+    const initFormRow = props.needInitFormRow ? [{ ...formItem, editing: true }] : [];
     form.value.list = props.defaultList?.length
       ? cloneDeep(props.defaultList).map((item) => ({
           editing: false,
           ...item,
         }))
-      : [{ ...formItem, editing: true }];
+      : initFormRow;
   }
 
   watchEffect(() => {

--- a/frontend/packages/web/src/views/system/message/components/expirationSettingDrawer.vue
+++ b/frontend/packages/web/src/views/system/message/components/expirationSettingDrawer.vue
@@ -10,10 +10,10 @@
     @cancel="handleCancel"
   >
     <n-scrollbar content-class="p-[24px]">
+      <div v-if="props.showTimeSetting" class="mb-[16px] font-medium text-[var(--text-n1)]">
+        {{ t('system.message.timeSetting') }}
+      </div>
       <div v-if="props.showTimeSetting" class="bg-[var(--text-n9)] p-[16px]">
-        <div class="text-[var(--text-n1)]">
-          {{ formTitleName }}
-        </div>
         <CrmBatchForm
           ref="batchFormRef"
           class="!p-0"
@@ -22,9 +22,11 @@
           :add-text="t('common.add')"
           validate-when-add
           :max-limit-length="10"
+          :need-init-form-row="false"
           :disabled-add-tooltip="t('system.message.maxLimit', { count: 10 })"
           @delete-row="handleDelete"
           @save-row="handleSave"
+          @cancel-row="handleCancelRow"
         />
       </div>
       <div class="my-[16px] font-medium text-[var(--text-n1)]">{{ t('system.message.scopedSettings') }}</div>
@@ -228,6 +230,12 @@
       // eslint-disable-next-line no-console
       console.log(e);
     }
+  }
+
+  function handleCancelRow() {
+    batchFormRef.value?.formValidate(() => {
+      // 取消时候刷新验证
+    });
   }
 
   function handleConfirm() {

--- a/frontend/packages/web/src/views/system/message/locale/en-US.ts
+++ b/frontend/packages/web/src/views/system/message/locale/en-US.ts
@@ -55,4 +55,5 @@ export default {
   'system.message.toHeadAbove': 'To the head and above',
   'system.message.noticeOfDepartmentHead': 'Notice from the head of the level department',
   'system.message.departmentHeadTooltip': '0 represents the direct superior',
+  'system.message.timeSetting': 'Time configuration',
 };

--- a/frontend/packages/web/src/views/system/message/locale/zh-CN.ts
+++ b/frontend/packages/web/src/views/system/message/locale/zh-CN.ts
@@ -54,4 +54,5 @@ export default {
   'system.message.toHeadAbove': '向负责人及以上',
   'system.message.noticeOfDepartmentHead': '级部门负责人通知',
   'system.message.departmentHeadTooltip': '0 代表直属上级',
+  'system.message.timeSetting': '时间配置',
 };


### PR DESCRIPTION
【【消息设置】报价即将到期-点击齿轮-删除全部时间配置条数-保存-再次打开-直接点击保存，报错】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065385
【【消息设置】报价即将到期-新增重复的到期提醒-点取消，提示未及时消失】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065382
