### PR TITLE
fix: business title filter field type

### DIFF
--- a/frontend/packages/web/src/views/contract/businessTitle/components/businessTitleTable.vue
+++ b/frontend/packages/web/src/views/contract/businessTitle/components/businessTitleTable.vue
@@ -491,7 +491,7 @@
     {
       title: t('contract.businessTitle.capital'),
       dataIndex: 'registeredCapital',
-      type: FieldTypeEnum.INPUT_NUMBER,
+      type: FieldTypeEnum.INPUT,
     },
     {
       title: t('contract.businessTitle.address'),


### PR DESCRIPTION
【【工商抬头】高级筛选-注册资本小于/小于等于返回结果错误】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065557