### PR TITLE
fix: business title disabled third

### DIFF
--- a/frontend/packages/web/src/views/contract/businessTitle/components/businessTitleDrawer.vue
+++ b/frontend/packages/web/src/views/contract/businessTitle/components/businessTitleDrawer.vue
@@ -46,6 +46,7 @@
             :placeholder="t('contract.businessTitle.selectCompanyPlaceholder')"
             label-key="name"
             value-key="id"
+            :disabled="!isEnableQccConfig && form.id && originType === 'THIRD_PARTY'"
             @select="handleAutoFillInfo"
           />
         </n-form-item>

--- a/frontend/packages/web/src/views/system/business/components/integrationList.vue
+++ b/frontend/packages/web/src/views/system/business/components/integrationList.vue
@@ -468,7 +468,13 @@
                 >
                   {{ t('common.config') }}
                 </n-button>
-                <n-button size="small" type="default" class="outline--secondary px-[8px]" @click="testLink(item)">
+                <n-button
+                  :disabled="!item.hasConfig"
+                  size="small"
+                  type="default"
+                  class="outline--secondary px-[8px]"
+                  @click="testLink(item)"
+                >
                   {{ t('system.business.mailSettings.testLink') }}
                 </n-button>
               </div>


### PR DESCRIPTION
【【工商抬头】关闭企查查-编辑之前使用企查查添加的历史数据-发现页面仍展示添加方式】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065702
【【系统-企业设置】企查查的测试连接按钮默认初始化应该置灰不能点击】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065699
