### PR TITLE
fix: message go detail permission

### DIFF
--- a/frontend/packages/web/src/components/business/crm-message-list/index.vue
+++ b/frontend/packages/web/src/components/business/crm-message-list/index.vue
@@ -147,7 +147,7 @@
   const permissionConfig = {
     OPPORTUNITY_QUOTATION_READ: ['OPPORTUNITY_QUOTATION:READ'],
     CONTRACT_READ: ['CONTRACT:READ'],
-    CONTRACT_PAYMENT_RECORD_READ: ['CONTRACT_PAYMENT_RECORD:READ'],
+    CONTRACT_PAYMENT_PLAN_READ: ['CONTRACT_PAYMENT_PLAN:READ'],
   };
 
   const messageDetailConfig: Record<string, MessageDetailAction> = {
@@ -168,11 +168,11 @@
       action: openNewPageContract,
     },
     CONTRACT_PAYMENT_EXPIRING: {
-      permission: permissionConfig.CONTRACT_PAYMENT_RECORD_READ,
+      permission: permissionConfig.CONTRACT_PAYMENT_PLAN_READ,
       action: openNewPageContractPaymentPlan,
     },
     CONTRACT_PAYMENT_EXPIRED: {
-      permission: permissionConfig.CONTRACT_PAYMENT_RECORD_READ,
+      permission: permissionConfig.CONTRACT_PAYMENT_PLAN_READ,
       action: openNewPageContractPaymentPlan,
     },
   };


### PR DESCRIPTION
【【消息通知】有回款计划的权限，但是回款计划的系统通知不能跳转，原因是回款计划消息通知的跳转配置成了回款记录的权限】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001065865