### PR TITLE
fix: formula ir parse default val

### DIFF
--- a/frontend/packages/web/src/components/business/crm-formula/index.vue
+++ b/frontend/packages/web/src/components/business/crm-formula/index.vue
@@ -83,7 +83,10 @@
     const { formula } = props.fieldConfig;
     const { ir } = safeParseFormula(formula ?? '');
 
-    if (!ir) return;
+    if (!ir) {
+      value.value = 0;
+      return;
+    }
     const contextMatch = props.path.match(/^([^[]+)\[(\d+)\]\./);
 
     const context = contextMatch


### PR DESCRIPTION
【【合同/报价】1.5的合同/报价表单字段-有表单计算字段&新增子表格计算字段的数据-升级1.5.1后，编辑合同/报价发现表单计算字段&新增子表格计算字段&累积金额初识化为计算字段的数据显示不正常】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001066191