### PR TITLE
fix: formula calc days

### DIFF
--- a/frontend/packages/web/src/components/business/crm-formula/formula-runtime/functions/days.ts
+++ b/frontend/packages/web/src/components/business/crm-formula/formula-runtime/functions/days.ts
@@ -1,4 +1,5 @@
 export default function DAYS(end: number, start: number): number {
-  if (typeof end !== 'number' || typeof start !== 'number') return 0;
-  return Math.floor(end - start);
+  if (!Number.isFinite(end) || !Number.isFinite(start)) return 0;
+
+  return Math.floor(end) - Math.floor(start);
 }


### PR DESCRIPTION
【【系统】合同表单设置-系统累计金额-公式-DAYS()计算两个相差几秒的日期字段，发现计算结果为1】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001066280