### PR TITLE
fix: approval status delete text

### DIFF
--- a/frontend/packages/web/src/views/contract/contract/components/contractTable.vue
+++ b/frontend/packages/web/src/views/contract/contract/components/contractTable.vue
@@ -396,7 +396,6 @@
   }
 
   function showCustomerDrawer(params: { customerId: string; inCustomerPool: boolean; poolId: string }) {
-    activeSourceId.value = params.customerId;
     emit(
       'openCustomerDrawer',
       {

--- a/frontend/packages/web/src/views/contract/invoice/components/invoiceTable.vue
+++ b/frontend/packages/web/src/views/contract/invoice/components/invoiceTable.vue
@@ -316,11 +316,13 @@
 
   const showDetailDrawer = ref(false);
 
-  function handleDelete(row: any) {
+  function handleDelete(row: any, approvalEnable: boolean) {
     openModal({
       type: 'error',
       title: t('common.deleteConfirmTitle', { name: row.name }),
-      content: deleteInvoiceContentMap[row.approvalStatus as ContractInvoiceStatusEnum],
+      content: approvalEnable
+        ? deleteInvoiceContentMap[row.approvalStatus as ContractInvoiceStatusEnum]
+        : deleteInvoiceContentMap[ContractInvoiceStatusEnum.NONE],
       positiveText: t('common.confirmDelete'),
       negativeText: t('common.cancel'),
       onPositiveClick: async () => {
@@ -358,7 +360,7 @@
     }
   }
 
-  async function handleActionSelect(row: ContractInvoiceItem, actionKey: string) {
+  async function handleActionSelect(row: ContractInvoiceItem, actionKey: string, approvalEnable: boolean) {
     switch (actionKey) {
       case 'edit':
         handleEdit(row.id);
@@ -367,7 +369,7 @@
         handleRevoke(row);
         break;
       case 'delete':
-        handleDelete(row);
+        handleDelete(row, approvalEnable);
         break;
       case 'approval':
         showDetail(row.id);
@@ -417,7 +419,7 @@
       render: (row: ContractInvoiceItem) =>
         h(CrmOperationButton, {
           groupList: getOperationGroupList(row, dicApprovalEnable.value),
-          onSelect: (key: string) => handleActionSelect(row, key),
+          onSelect: (key: string) => handleActionSelect(row, key, dicApprovalEnable.value),
         }),
     },
     specialRender: {


### PR DESCRIPTION
【【发票】模块设置，关闭发票审批-删除新建发票，删除的提示为提审状态的提示，删除历史打开发票审批按钮时的发票，发现提示均为相应审批状态的删除提示】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001066429

【【合同】关闭合同审批-查看关闭前创建的合同详情-点击客户名称返回查看计划/记录/发票tab标签页数据为空】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001066443