### PR TITLE
fix-bug-seed2

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
@@ -228,19 +228,20 @@ public class DepartmentService extends MoveNodeService {
      */
     @CacheEvict(value = "dept_tree_cache", key = "#orgId", beforeInvocation = true)
     public void delete(List<String> ids, String operator, String orgId) {
-        if (deleteCheck(ids, orgId)) {
-            List<Department> departmentList = departmentMapper.selectByIds(ids);
-            //刪除部門
-            departmentMapper.deleteByIds(ids);
-            List<LogDTO> logs = new ArrayList<>();
-            // 添加日志上下文
-            departmentList.forEach(department -> {
-                LogDTO logDTO = new LogDTO(department.getOrganizationId(), department.getId(), operator, LogType.DELETE, LogModule.SYSTEM_ORGANIZATION, department.getName());
-                logDTO.setOriginalValue(department);
-                logs.add(logDTO);
-            });
-            logService.batchAdd(logs);
+        if (!deleteCheck(ids, orgId)) {
+            throw new GenericException(Translator.get("department.delete.has.user"));
         }
+        List<Department> departmentList = departmentMapper.selectByIds(ids);
+        //刪除部門
+        departmentMapper.deleteByIds(ids);
+        List<LogDTO> logs = new ArrayList<>();
+        // 添加日志上下文
+        departmentList.forEach(department -> {
+            LogDTO logDTO = new LogDTO(department.getOrganizationId(), department.getId(), operator, LogType.DELETE, LogModule.SYSTEM_ORGANIZATION, department.getName());
+            logDTO.setOriginalValue(department);
+            logs.add(logDTO);
+        });
+        logService.batchAdd(logs);
     }
 
 

--- a/backend/crm/src/main/resources/i18n/cordys-crm_en_US.properties
+++ b/backend/crm/src/main/resources/i18n/cordys-crm_en_US.properties
@@ -401,6 +401,7 @@ user_resource_exist=Employee has untransferred account resources, cannot be dele
 permission.organization.sync=Sync
 permission.organization.user.reset_password=Reset password
 department.internal=Built-in department cannot be deleted
+department.delete.has.user=Cannot delete department with employees
 import_phone_validate=Invalid phone number
 employee_length=Employee number length cannot exceed 255 characters
 position_length=Position length cannot exceed 255 characters

--- a/backend/crm/src/main/resources/i18n/cordys-crm_zh_CN.properties
+++ b/backend/crm/src/main/resources/i18n/cordys-crm_zh_CN.properties
@@ -403,6 +403,7 @@ user_resource_exist=该员工存在未转移的客户资源，无法删除
 permission.organization.sync=同步
 permission.organization.user.reset_password=重置密码
 department.internal=内置部门不允许删除
+department.delete.has.user=部门下存在员工，无法删除
 import_phone_validate=手机号不合法
 employee_length=工号长度不能超过255个字符
 position_length=职位长度不能超过255个字符

--- a/frontend/packages/web/src/views/system/org/components/moduleTree.vue
+++ b/frontend/packages/web/src/views/system/org/components/moduleTree.vue
@@ -361,9 +361,10 @@
             Message.success(t('common.deleteSuccess'));
             initTree(true);
           }
-        } catch (error) {
+        } catch (error: any) {
           // eslint-disable-next-line no-console
           console.log(error);
+          Message.error(error.response?.data?.message || t('common.deleteFailed'));
         }
       },
     });


### PR DESCRIPTION
Dogfooding试标题目
fix-bug-by-trae
prompt:当用户选择删除一个部门后,若该部门下还有员工,系统不会实际删除部门,但接口仍返回成功,所以前端无法区分删除成功还是删除未执行。用户会误以为部门已删除,实际上部门仍存在,且不清楚未删除的原因。帮我处理这个缺陷。 
模型：Doubao Seed Code 2.0