### PR TITLE
fix: 修复部门删除时无法区分删除成功还是删除未执行的问题

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
@@ -228,19 +228,20 @@ public class DepartmentService extends MoveNodeService {
      */
     @CacheEvict(value = "dept_tree_cache", key = "#orgId", beforeInvocation = true)
     public void delete(List<String> ids, String operator, String orgId) {
-        if (deleteCheck(ids, orgId)) {
-            List<Department> departmentList = departmentMapper.selectByIds(ids);
-            //刪除部門
-            departmentMapper.deleteByIds(ids);
-            List<LogDTO> logs = new ArrayList<>();
-            // 添加日志上下文
-            departmentList.forEach(department -> {
-                LogDTO logDTO = new LogDTO(department.getOrganizationId(), department.getId(), operator, LogType.DELETE, LogModule.SYSTEM_ORGANIZATION, department.getName());
-                logDTO.setOriginalValue(department);
-                logs.add(logDTO);
-            });
-            logService.batchAdd(logs);
+        if (!deleteCheck(ids, orgId)) {
+            throw new GenericException(Translator.get("department.has_employees"));
         }
+        List<Department> departmentList = departmentMapper.selectByIds(ids);
+        //刪除部門
+        departmentMapper.deleteByIds(ids);
+        List<LogDTO> logs = new ArrayList<>();
+        // 添加日志上下文
+        departmentList.forEach(department -> {
+            LogDTO logDTO = new LogDTO(department.getOrganizationId(), department.getId(), operator, LogType.DELETE, LogModule.SYSTEM_ORGANIZATION, department.getName());
+            logDTO.setOriginalValue(department);
+            logs.add(logDTO);
+        });
+        logService.batchAdd(logs);
     }
 
 

--- a/backend/crm/src/main/resources/i18n/cordys-crm_en_US.properties
+++ b/backend/crm/src/main/resources/i18n/cordys-crm_en_US.properties
@@ -401,6 +401,7 @@ user_resource_exist=Employee has untransferred account resources, cannot be dele
 permission.organization.sync=Sync
 permission.organization.user.reset_password=Reset password
 department.internal=Built-in department cannot be deleted
+department.has_employees=Department has employees, cannot be deleted
 import_phone_validate=Invalid phone number
 employee_length=Employee number length cannot exceed 255 characters
 position_length=Position length cannot exceed 255 characters

--- a/backend/crm/src/main/resources/i18n/cordys-crm_zh_CN.properties
+++ b/backend/crm/src/main/resources/i18n/cordys-crm_zh_CN.properties
@@ -403,6 +403,7 @@ user_resource_exist=该员工存在未转移的客户资源，无法删除
 permission.organization.sync=同步
 permission.organization.user.reset_password=重置密码
 department.internal=内置部门不允许删除
+department.has_employees=该部门下存在员工，无法删除
 import_phone_validate=手机号不合法
 employee_length=工号长度不能超过255个字符
 position_length=职位长度不能超过255个字符

--- a/backend/crm/src/test/java/cn/cordys/crm/system/controller/DepartmentControllerTests.java
+++ b/backend/crm/src/test/java/cn/cordys/crm/system/controller/DepartmentControllerTests.java
@@ -77,15 +77,31 @@ public class DepartmentControllerTests extends BaseTest {
 
     @Test
     @Order(5)
-    public void departmentDeleteCHeck() throws Exception {
-        this.requestPost(DEPARTMENT_DELETE_CHECK, List.of("7"));
+    public void departmentDeleteCheck() throws Exception {
+        // 部门7下没有员工，应该返回true（可以删除）
+        this.requestPost(DEPARTMENT_DELETE_CHECK, List.of("7")).andExpect(status().isOk());
+        // 部门8下有员工（根据init_department_test.sql），应该返回false（不能删除）
+        this.requestPost(DEPARTMENT_DELETE_CHECK, List.of("8")).andExpect(status().isOk());
     }
 
     @Test
     @Order(6)
     public void departmentDelete() throws Exception {
-        this.requestPost(DEPARTMENT_DELETE, List.of("7"));
-        this.requestPost(DEPARTMENT_DELETE, List.of("8"));
+        // 删除部门7（没有员工），应该成功
+        this.requestPost(DEPARTMENT_DELETE, List.of("7")).andExpect(status().isOk());
+    }
+
+    @Test
+    @Order(7)
+    public void departmentDeleteWithEmployees() throws Exception {
+        // 删除部门8（有员工），应该返回500错误并提示"该部门下存在员工，无法删除"
+        this.requestPost(DEPARTMENT_DELETE, List.of("8"))
+                .andExpect(status().is5xxServerError())
+                .andExpect(result -> {
+                    String content = result.getResponse().getContentAsString();
+                    assert content.contains("该部门下存在员工") || content.contains("Department has employees")
+                            : "Expected error message about employees, but got: " + content;
+                });
     }
 
 


### PR DESCRIPTION
- 当部门下还有员工时，系统现在会抛出异常并返回错误信息

- 添加国际化消息：department.has_employees

- 完善测试案例，添加删除有员工部门的测试场景

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.