### PR TITLE
当用户选择删除一个部门后,若该部门下还有员工,系统不会实际删除部门,但接口仍返回成功,所以前端无法区分删除成功还是删除未执行。用户会误以为…

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/system/controller/DepartmentController.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/controller/DepartmentController.java
@@ -71,8 +71,8 @@ public class DepartmentController {
     @PostMapping("/delete")
     @RequiresPermissions(PermissionConstants.SYS_ORGANIZATION_DELETE)
     @Operation(summary = "组织架构-删除部门")
-    public void deleteDepartment(@RequestBody @NotEmpty List<String> ids) {
-        departmentService.delete(ids, SessionUtils.getUserId(), OrganizationContext.getOrganizationId());
+    public boolean deleteDepartment(@RequestBody @NotEmpty List<String> ids) {
+        return departmentService.delete(ids, SessionUtils.getUserId(), OrganizationContext.getOrganizationId());
 
     }
 

--- a/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
@@ -225,9 +225,10 @@ public class DepartmentService extends MoveNodeService {
      * 刪除部门
      *
      * @param ids
+     * @return 删除结果
      */
     @CacheEvict(value = "dept_tree_cache", key = "#orgId", beforeInvocation = true)
-    public void delete(List<String> ids, String operator, String orgId) {
+    public boolean delete(List<String> ids, String operator, String orgId) {
         if (deleteCheck(ids, orgId)) {
             List<Department> departmentList = departmentMapper.selectByIds(ids);
             //刪除部門
@@ -240,7 +241,9 @@ public class DepartmentService extends MoveNodeService {
                 logs.add(logDTO);
             });
             logService.batchAdd(logs);
+            return true;
         }
+        return false;
     }
 
 

--- a/frontend/packages/web/src/views/system/org/components/moduleTree.vue
+++ b/frontend/packages/web/src/views/system/org/components/moduleTree.vue
@@ -357,9 +357,13 @@
       onPositiveClick: async () => {
         try {
           if (isNotAllow) {
-            await deleteDepartment(offspringIds);
-            Message.success(t('common.deleteSuccess'));
-            initTree(true);
+            const result = await deleteDepartment(offspringIds);
+            if (result) {
+              Message.success(t('common.deleteSuccess'));
+              initTree(true);
+            } else {
+              Message.error(t('org.deleteExistUserDepartment'));
+            }
           }
         } catch (error) {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
…部门已删除,实际上部门仍存在,且不清楚未删除的原因。帮我处理这个缺陷。

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.