### PR TITLE
当用户选择删除一个部门后,若该部门下还有员工,系统不会实际删除部门,但接口仍返回成功,所以前端无法区分删除成功还是删除未执行。用户会误以为…

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/system/controller/DepartmentController.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/controller/DepartmentController.java
@@ -69,12 +69,11 @@ public class DepartmentController {
 
 
     @PostMapping("/delete")
-    @RequiresPermissions(PermissionConstants.SYS_ORGANIZATION_DELETE)
-    @Operation(summary = "组织架构-删除部门")
-    public void deleteDepartment(@RequestBody @NotEmpty List<String> ids) {
-        departmentService.delete(ids, SessionUtils.getUserId(), OrganizationContext.getOrganizationId());
-
-    }
+   @RequiresPermissions(PermissionConstants.SYS_ORGANIZATION_DELETE)
+   @Operation(summary = "组织架构-删除部门")
+   public boolean deleteDepartment(@RequestBody @NotEmpty List<String> ids) {
+       return departmentService.delete(ids, SessionUtils.getUserId(), OrganizationContext.getOrganizationId());
+   }
 
 
     @PostMapping("/sort")

--- a/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/service/DepartmentService.java
@@ -222,26 +222,29 @@ public class DepartmentService extends MoveNodeService {
     }
 
     /**
-     * 刪除部门
-     *
-     * @param ids
-     */
-    @CacheEvict(value = "dept_tree_cache", key = "#orgId", beforeInvocation = true)
-    public void delete(List<String> ids, String operator, String orgId) {
-        if (deleteCheck(ids, orgId)) {
-            List<Department> departmentList = departmentMapper.selectByIds(ids);
-            //刪除部門
-            departmentMapper.deleteByIds(ids);
-            List<LogDTO> logs = new ArrayList<>();
-            // 添加日志上下文
-            departmentList.forEach(department -> {
-                LogDTO logDTO = new LogDTO(department.getOrganizationId(), department.getId(), operator, LogType.DELETE, LogModule.SYSTEM_ORGANIZATION, department.getName());
-                logDTO.setOriginalValue(department);
-                logs.add(logDTO);
-            });
-            logService.batchAdd(logs);
-        }
-    }
+    * 刪除部门
+    *
+    * @param ids
+    * @return 是否删除成功
+    */
+   @CacheEvict(value = "dept_tree_cache", key = "#orgId", beforeInvocation = true)
+   public boolean delete(List<String> ids, String operator, String orgId) {
+       if (deleteCheck(ids, orgId)) {
+           List<Department> departmentList = departmentMapper.selectByIds(ids);
+           //刪除部門
+           departmentMapper.deleteByIds(ids);
+           List<LogDTO> logs = new ArrayList<>();
+           // 添加日志上下文
+           departmentList.forEach(department -> {
+               LogDTO logDTO = new LogDTO(department.getOrganizationId(), department.getId(), operator, LogType.DELETE, LogModule.SYSTEM_ORGANIZATION, department.getName());
+               logDTO.setOriginalValue(department);
+               logs.add(logDTO);
+           });
+           logService.batchAdd(logs);
+           return true;
+       }
+       return false;
+   }
 
 
     /**

--- a/frontend/packages/web/src/views/system/org/components/moduleTree.vue
+++ b/frontend/packages/web/src/views/system/org/components/moduleTree.vue
@@ -339,35 +339,39 @@
   }
 
   /**
-   * 删除
-   */
-  async function handleDelete(option: CrmTreeNodeData) {
-    const offspringIds = [option.id, ...getSpringIds((option as CrmTreeNodeData).children)];
-    const isNotAllow = await checkDeleteDepartment(offspringIds);
-    openModal({
-      type: 'error',
-      title: t('common.deleteConfirmTitle', { name: characterLimit(option.name) }),
-      content: !isNotAllow ? t('org.deleteExistUserDepartment') : t('org.deleteDepartmentContent'),
-      positiveText: !isNotAllow ? t('org.ok') : t('common.confirm'),
-      negativeText: !isNotAllow ? '' : t('common.cancel'),
-      positiveButtonProps: {
-        type: !isNotAllow ? 'primary' : 'error',
-        size: 'medium',
-      },
-      onPositiveClick: async () => {
-        try {
-          if (isNotAllow) {
-            await deleteDepartment(offspringIds);
-            Message.success(t('common.deleteSuccess'));
-            initTree(true);
-          }
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.log(error);
-        }
-      },
-    });
-  }
+    * 删除
+    */
+   async function handleDelete(option: CrmTreeNodeData) {
+     const offspringIds = [option.id, ...getSpringIds((option as CrmTreeNodeData).children)];
+     const isNotAllow = await checkDeleteDepartment(offspringIds);
+     openModal({
+       type: 'error',
+       title: t('common.deleteConfirmTitle', { name: characterLimit(option.name) }),
+       content: !isNotAllow ? t('org.deleteExistUserDepartment') : t('org.deleteDepartmentContent'),
+       positiveText: !isNotAllow ? t('org.ok') : t('common.confirm'),
+       negativeText: !isNotAllow ? '' : t('common.cancel'),
+       positiveButtonProps: {
+         type: !isNotAllow ? 'primary' : 'error',
+         size: 'medium',
+       },
+       onPositiveClick: async () => {
+         try {
+           if (isNotAllow) {
+             const result = await deleteDepartment(offspringIds);
+             if (result) {
+               Message.success(t('common.deleteSuccess'));
+               initTree(true);
+             } else {
+               Message.error(t('org.deleteExistUserDepartment'));
+             }
+           }
+         } catch (error) {
+           // eslint-disable-next-line no-console
+           console.log(error);
+         }
+       },
+     });
+   }
 
   function handleFolderMoreSelect(item: ActionsItem, option: CrmTreeNodeData) {
     switch (item.key) {


### PR DESCRIPTION
…部门已删除,实际上部门仍存在,且不清楚未删除的原因。帮我处理这个缺陷。

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.