### PR TITLE
fix: business title module form

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/contract/constants/BusinessTitleConstants.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/contract/constants/BusinessTitleConstants.java
@@ -10,7 +10,11 @@ public enum BusinessTitleConstants {
     PHONE_NUMBER("phoneNumber", "注册电话", "Phone number"),
     REGISTERED_CAPITAL("registeredCapital", "注册资本", "Registered capital"),
     COMPANY_SIZE("companySize", "公司规模", "Customer size"),
-    registration_number("registrationNumber", "工商注册账号", "Registration number");
+    REGISTRATION_NUMBER("registrationNumber", "工商注册账号", "Registration number"),
+    PROVINCE("province", "省", "Province"),
+    CITY("city", "市", "City"),
+    SCALE("scale", "企业规模", "Scale"),
+    INDUSTRY("industry", "国标行业", "Industry");
 
     private final String key;
     private final String ch;

--- a/backend/crm/src/main/java/cn/cordys/crm/contract/excel/constants/BusinessTitleImportFiled.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/contract/excel/constants/BusinessTitleImportFiled.java
@@ -20,10 +20,10 @@ public enum BusinessTitleImportFiled {
     PHONE_NUMBER("phoneNumber", "注册电话", "Phone number", BusinessTitleExcelData::getPhoneNumber),
     REGISTERED_CAPITAL("registeredCapital", "注册资本", "Registered capital", BusinessTitleExcelData::getRegisteredCapital),
     COMPANY_SIZE("companySize", "公司规模", "Customer size", BusinessTitleExcelData::getCompanySize),
-    registration_number("registrationNumber", "工商注册账号", "Registration number", BusinessTitleExcelData::getRegistrationNumber),
+    REGISTRATION_NUMBER("registrationNumber", "工商注册账号", "Registration number", BusinessTitleExcelData::getRegistrationNumber),
     PROVINCE("province", "省", "Province", BusinessTitleExcelData::getProvince),
     CITY("city", "市", "City", BusinessTitleExcelData::getCity),
-    Scale("scale", "企业规模", "Scale", BusinessTitleExcelData::getScale),
+    SCALE("scale", "企业规模", "Scale", BusinessTitleExcelData::getScale),
     INDUSTRY("industry", "国标行业", "Industry", BusinessTitleExcelData::getIndustry),
     REMARK("remark", "备注", "Remark", BusinessTitleExcelData::getRemark);
 


### PR DESCRIPTION
fix: business title module form  --bug=1067794@tapd-34675357 --user=陈建星 【模块设置】表单数据源为工商抬头-列表显示字段和表单列表不一致 https://www.tapd.cn/34675357/s/1888523 