### PR TITLE
当用户选择删除一个部门后,若该部门下还有员工,系统不会实际删除部门,但接口仍返回成功,所以前端无法区分删除成功还是删除未执行。用户会误以为部门已删除,实际上部门仍存在,且不清楚未删除的原因。帮我处理这个缺陷。

### DIFF
--- a/frontend/packages/web/src/views/system/org/components/moduleTree.vue
+++ b/frontend/packages/web/src/views/system/org/components/moduleTree.vue
@@ -343,27 +343,27 @@
    */
   async function handleDelete(option: CrmTreeNodeData) {
     const offspringIds = [option.id, ...getSpringIds((option as CrmTreeNodeData).children)];
-    const isNotAllow = await checkDeleteDepartment(offspringIds);
+    const canDelete = await checkDeleteDepartment(offspringIds);
     openModal({
       type: 'error',
       title: t('common.deleteConfirmTitle', { name: characterLimit(option.name) }),
-      content: !isNotAllow ? t('org.deleteExistUserDepartment') : t('org.deleteDepartmentContent'),
-      positiveText: !isNotAllow ? t('org.ok') : t('common.confirm'),
-      negativeText: !isNotAllow ? '' : t('common.cancel'),
+      content: !canDelete ? t('org.deleteExistUserDepartment') : t('org.deleteDepartmentContent'),
+      positiveText: !canDelete ? t('org.ok') : t('common.confirm'),
+      negativeText: !canDelete ? '' : t('common.cancel'),
       positiveButtonProps: {
-        type: !isNotAllow ? 'primary' : 'error',
+        type: !canDelete ? 'primary' : 'error',
         size: 'medium',
       },
       onPositiveClick: async () => {
         try {
-          if (isNotAllow) {
+          if (canDelete) {
             await deleteDepartment(offspringIds);
             Message.success(t('common.deleteSuccess'));
             initTree(true);
           }
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.log(error);
+        } catch (error: any) {
+          const errorMessage = error?.response?.data?.message || error?.message || t('common.deleteFailed');
+          Message.error(errorMessage);
         }
       },
     });


### PR DESCRIPTION
Cordys CRM 是新一代的开源AICRM系统,是集信息化、数字化、智能化于一体的客户关系管理系统。CordysCRM能够帮助企业实现从线索到回款(L2C)的全流程精细化管理,覆盖线索获取、智能分配、客户与联系人管理、商机跟进、合同签约及回款执行,构建端到端的销售运营闭环。