### PR TITLE
fix: account source list reason id is null

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/customer/mapper/ExtCustomerMapper.xml
+++ b/backend/crm/src/main/java/cn/cordys/crm/customer/mapper/ExtCustomerMapper.xml
@@ -198,7 +198,7 @@
 
     <select id="sourceList" resultType="cn.cordys.crm.customer.dto.response.CustomerListResponse">
         select distinct c.id, c.`name`, if(c.in_shared_pool, null, c.owner) as owner, c.create_time, c.update_time, c.create_user, c.update_user, c.collection_time, c.pool_id,
-        c.follower, c.follow_time
+        c.follower, c.follow_time, c.reason_id
         from customer c left join customer_collaboration cc on c.id = cc.customer_id and cc.user_id = #{userId}
 
         <include refid="fieldConditionJoin">


### PR DESCRIPTION
fix: account source list reason id is null  --bug=1068422@tapd-34675357 --user=陈建星 【合同】新建合同-选择客户窗口-数据源列表显示字段回收原因为空 https://www.tapd.cn/34675357/s/1902074 