### PR TITLE
fix(upload): close FileInputStream in upload

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/system/service/FileCommonService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/service/FileCommonService.java
@@ -57,10 +57,11 @@ public class FileCommonService {
      */
     public void upload(File file, FileRequest request) {
         try {
-            FileInputStream inputStream = new FileInputStream(file);
-            FileCenter.getRepository(request.getStorage()).saveFile(inputStream, request);
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            try (FileInputStream inputStream = new FileInputStream(file)) {
+                FileCenter.getRepository(request.getStorage()).saveFile(inputStream, request);
+                } catch (Exception e) {
+                log.error(e.getMessage(), e);
+            }
         }
     }
 


### PR DESCRIPTION
Spotted something in backend/crm/src/main/java/cn/cordys/crm/system/service/FileCommonService.java that might be worth a look: The resource opened there can leak if upload exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path — happy to close if this isn’t useful.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.