### PR TITLE
docs: 修正商机添加接口的 Swagger 必填描述

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/dto/request/OpportunityAddRequest.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/dto/request/OpportunityAddRequest.java
@@ -18,20 +18,20 @@ public class OpportunityAddRequest {
     private String name;
 
     @Size(max = 32)
-    @Schema(description = "客户id")
+    @Schema(description = "客户id", requiredMode = Schema.RequiredMode.REQUIRED)
     private String customerId;
 
-    @Schema(description = "金额")
+    @Schema(description = "金额", requiredMode = Schema.RequiredMode.REQUIRED)
     private BigDecimal amount;
 
-    @Schema(description = "意向产品", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "意向产品")
     private List<String> products;
 
     @Schema(description = "可能性")
     private BigDecimal possible;
 
     @Size(max = 32)
-    @Schema(description = "联系人", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "联系人")
     private String contactId;
 
     @Size(max = 32)
@@ -39,7 +39,7 @@ public class OpportunityAddRequest {
     private String owner;
 
 
-    @Schema(description = "结束时间")
+    @Schema(description = "结束时间", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long expectedEndTime;
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
在分析 `OpportunityAddRequest` 代码时，发现部分字段（如 contactId 等）在 Swagger 文档中被标记为 `REQUIRED`，但这与后端实际业务校验逻辑（未强制必填）不符。此 PR 旨在修正 Swagger 注解描述，以提高 API 文档的准确性，避免前端开发人员误读接口规范。

### Summary of your change
移除了 `OpportunityAddRequest` 中非必填字段的 `@Schema(requiredMode = Schema.RequiredMode.REQUIRED)` 注解。
仅修改了 Swagger 元数据描述，不涉及任何业务逻辑变更。

### Please indicate you've done the following:
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

#### 附加说明 / 截图
以下是前端“新建商机”界面的截图，可以确认 `contactId` 等字段在前端表单中并非必填项，特此修正后端 Swagger 文档以保持一致：
<img width="1912" height="948" alt="1" src="https://github.com/user-attachments/assets/2d62379d-966d-47ec-b306-fef3d2778cb0" />
<img width="1912" height="948" alt="2" src="https://github.com/user-attachments/assets/81376f60-1d32-4b28-a805-e4fcac5b0f8b" />
