### PR TITLE
.4062073974432528:a22aceba03db01133b825b3b4cc66ec3_69edc37876b23b934f810ba1.69edda5d76b23b934f810e1c.69edda5c0a1bff46c4e150c8:Trae CN.T(2026/4/26 17:26:53)

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/clue/service/ClueOwnerHistoryService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/clue/service/ClueOwnerHistoryService.java
@@ -70,12 +70,20 @@ public class ClueOwnerHistoryService {
         List<DictConfig> configs = dictConfigMapper.selectListByLambda(configLambdaQueryWrapper);
         boolean showReason = CollectionUtils.isNotEmpty(configs) && configs.getFirst().getEnabled();
 
-        Map<String, UserDeptDTO> userDeptMap = baseService.getUserDeptMapByUserIds(new ArrayList<>(ownerIds), orgId);
+        Map<String, UserDeptDTO> userDeptMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, UserDeptDTO> originUserDeptMap = baseService.getUserDeptMapByUserIds(new ArrayList<>(ownerIds), orgId);
+        userDeptMap.putAll(originUserDeptMap);
 
-        Map<String, String> userNameMap = baseService.getUserNameMap(userIds);
+        Map<String, String> userNameMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        userNameMap.putAll(baseService.getUserNameMap(userIds));
 
-        List<Dict> dictList = dictMapper.selectByIds(new ArrayList<>(reasonIds));
-        Map<String, String> dictNameMap = dictList.stream().collect(Collectors.toMap(Dict::getId, Dict::getName));
+        Map<String, String> dictNameMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (!reasonIds.isEmpty()) {
+            List<Dict> dictList = dictMapper.selectByIds(new ArrayList<>(reasonIds));
+            for (Dict dict : dictList) {
+                dictNameMap.put(dict.getId(), dict.getName());
+            }
+        }
 
         return owners
                 .stream()
@@ -93,10 +101,18 @@ public class ClueOwnerHistoryService {
                     } else {
                         clueOwner.setReasonName(dictNameMap.get(clueOwner.getReasonId()));
                     }
-                    clueOwner.setOwnerName(userNameMap.get(clueOwner.getOwner()));
-                    clueOwner.setOperatorName(userNameMap.get(clueOwner.getOperator()));
+                    clueOwner.setOwnerName(getUserNameOrDefault(userNameMap, clueOwner.getOwner()));
+                    clueOwner.setOperatorName(getUserNameOrDefault(userNameMap, clueOwner.getOperator()));
                     return clueOwner;
                 }).toList();
+    }
+
+    private String getUserNameOrDefault(Map<String, String> userNameMap, String userId) {
+        if (StringUtils.isBlank(userId)) {
+            return "未知用户";
+        }
+        String name = userNameMap.get(userId);
+        return StringUtils.isNotBlank(name) ? name : "未知用户";
     }
 
     public ClueOwner add(Clue clue, String userId, Boolean addReason) {

--- a/backend/crm/src/main/java/cn/cordys/crm/customer/service/CustomerOwnerHistoryService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/customer/service/CustomerOwnerHistoryService.java
@@ -66,12 +66,20 @@ public class CustomerOwnerHistoryService {
             reasonIds.add(owner.getReasonId());
         }
 
-        Map<String, UserDeptDTO> userDeptMap = baseService.getUserDeptMapByUserIds(new ArrayList<>(ownerIds), orgId);
+        Map<String, UserDeptDTO> userDeptMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, UserDeptDTO> originUserDeptMap = baseService.getUserDeptMapByUserIds(new ArrayList<>(ownerIds), orgId);
+        userDeptMap.putAll(originUserDeptMap);
 
-        Map<String, String> userNameMap = baseService.getUserNameMap(userIds);
+        Map<String, String> userNameMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        userNameMap.putAll(baseService.getUserNameMap(userIds));
 
-        List<Dict> dictList = dictMapper.selectByIds(new ArrayList<>(reasonIds));
-        Map<String, String> dictNameMap = dictList.stream().collect(Collectors.toMap(Dict::getId, Dict::getName));
+        Map<String, String> dictNameMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (!reasonIds.isEmpty()) {
+            List<Dict> dictList = dictMapper.selectByIds(new ArrayList<>(reasonIds));
+            for (Dict dict : dictList) {
+                dictNameMap.put(dict.getId(), dict.getName());
+            }
+        }
 
         LambdaQueryWrapper<DictConfig> configLambdaQueryWrapper = new LambdaQueryWrapper<>();
         configLambdaQueryWrapper.eq(DictConfig::getModule, DictModule.CUSTOMER_POOL_RS.name()).eq(DictConfig::getOrganizationId, orgId);
@@ -94,10 +102,18 @@ public class CustomerOwnerHistoryService {
                     } else {
                         customerOwner.setReasonName(dictNameMap.get(customerOwner.getReasonId()));
                     }
-                    customerOwner.setOwnerName(userNameMap.get(customerOwner.getOwner()));
-                    customerOwner.setOperatorName(userNameMap.get(customerOwner.getOperator()));
+                    customerOwner.setOwnerName(getUserNameOrDefault(userNameMap, customerOwner.getOwner()));
+                    customerOwner.setOperatorName(getUserNameOrDefault(userNameMap, customerOwner.getOperator()));
                     return customerOwner;
                 }).toList();
+    }
+
+    private String getUserNameOrDefault(Map<String, String> userNameMap, String userId) {
+        if (StringUtils.isBlank(userId)) {
+            return "未知用户";
+        }
+        String name = userNameMap.get(userId);
+        return StringUtils.isNotBlank(name) ? name : "未知用户";
     }
 
     public CustomerOwner add(Customer customer, String userId, Boolean addReason) {

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/controller/OpportunityController.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/controller/OpportunityController.java
@@ -132,7 +132,7 @@ public class OpportunityController {
     @RequiresPermissions(value = {PermissionConstants.OPPORTUNITY_MANAGEMENT_UPDATE, PermissionConstants.OPPORTUNITY_MANAGEMENT_RESIGN}, logical = Logical.OR)
     @Operation(summary = "更新商机阶段")
     public void updateStage(@RequestBody OpportunityStageRequest request) {
-        opportunityService.updateStage(request, OrganizationContext.getOrganizationId());
+        opportunityService.updateStage(request, OrganizationContext.getOrganizationId(), SessionUtils.getUserId());
     }
 
     @PostMapping("/batch/update")

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/controller/OpportunityStageHistoryController.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/controller/OpportunityStageHistoryController.java
@@ -1,0 +1,32 @@
+package cn.cordys.crm.opportunity.controller;
+
+import cn.cordys.common.constants.PermissionConstants;
+import cn.cordys.context.OrganizationContext;
+import cn.cordys.crm.opportunity.dto.response.OpportunityStageHistoryResponse;
+import cn.cordys.crm.opportunity.service.OpportunityStageHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Resource;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@Tag(name = "商机阶段变更历史")
+@RestController
+@RequestMapping("/opportunity/stage/history")
+public class OpportunityStageHistoryController {
+    @Resource
+    private OpportunityStageHistoryService opportunityStageHistoryService;
+
+    @GetMapping("/list/{opportunityId}")
+    @RequiresPermissions(PermissionConstants.OPPORTUNITY_MANAGEMENT_READ)
+    @Operation(summary = "商机阶段变更历史列表")
+    public List<OpportunityStageHistoryResponse> list(@PathVariable String opportunityId) {
+        return opportunityStageHistoryService.list(opportunityId, OrganizationContext.getOrganizationId());
+    }
+}

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/domain/OpportunityStageHistory.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/domain/OpportunityStageHistory.java
@@ -1,0 +1,32 @@
+package cn.cordys.crm.opportunity.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+
+@Data
+@Table(name = "opportunity_stage_history")
+public class OpportunityStageHistory {
+
+    @Schema(description = "id")
+    private String id;
+
+    @Schema(description = "商机id")
+    private String opportunityId;
+
+    @Schema(description = "原阶段id")
+    private String fromStage;
+
+    @Schema(description = "新阶段id")
+    private String toStage;
+
+    @Schema(description = "变更时间")
+    private Long changeTime;
+
+    @Schema(description = "操作人")
+    private String operator;
+
+    @Schema(description = "失败原因id（当变更为失败阶段时）")
+    private String failureReasonId;
+}

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/dto/response/OpportunityStageHistoryResponse.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/dto/response/OpportunityStageHistoryResponse.java
@@ -1,0 +1,21 @@
+package cn.cordys.crm.opportunity.dto.response;
+
+import cn.cordys.crm.opportunity.domain.OpportunityStageHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+
+@Data
+public class OpportunityStageHistoryResponse extends OpportunityStageHistory {
+    @Schema(description = "原阶段名称")
+    private String fromStageName;
+
+    @Schema(description = "新阶段名称")
+    private String toStageName;
+
+    @Schema(description = "操作人名称")
+    private String operatorName;
+
+    @Schema(description = "失败原因名称")
+    private String failureReasonName;
+}

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityService.java
@@ -142,6 +142,8 @@ public class OpportunityService {
     private ExtOpportunityStageConfigMapper extOpportunityStageConfigMapper;
     @Resource
     private DataScopeService dataScopeService;
+    @Resource
+    private OpportunityStageHistoryService opportunityStageHistoryService;
 
     public PagerWithOption<List<OpportunityListResponse>> list(OpportunityPageRequest request, String userId, String orgId,
                                                                DeptDataPermissionDTO deptDataPermission, Boolean source) {
@@ -397,10 +399,10 @@ public class OpportunityService {
         Optional.ofNullable(opportunity).ifPresentOrElse(item -> {
             opportunityMapper.deleteByPrimaryKey(opportunity.getId());
             opportunityFieldService.deleteByResourceId(opportunity.getId());
+            opportunityStageHistoryService.deleteByOpportunityId(opportunity.getId());
         }, () -> {
             throw new GenericException("opportunity_not_found");
         });
-        // 添加日志上下文
         OperationLogContext.setResourceName(opportunity.getName());
 
         commonNoticeSendService.sendNotice(NotificationConstants.Module.OPPORTUNITY,
@@ -414,7 +416,6 @@ public class OpportunityService {
      */
     public void transfer(OpportunityTransferRequest request, String userId, String orgId) {
         List<StageConfigResponse> stageConfigList = extOpportunityStageConfigMapper.getStageConfigList(orgId);
-        // 过滤出成功阶段
         StageConfigResponse successConfig = stageConfigList.stream().filter(config ->
                 Strings.CI.equals(config.getType(), OpportunityStageType.END.name()) && Strings.CI.equals(config.getRate(), "100")
         ).findFirst().get();
@@ -428,16 +429,32 @@ public class OpportunityService {
         }
         List<String> ids = opportunityList.stream().map(Opportunity::getId).toList();
 
-        long nextPos = getNextPos(orgId, stageConfigList.getFirst().getId());
+        String firstStageId = stageConfigList.getFirst().getId();
+        Map<String, String> oldStageMap = opportunityList.stream()
+                .collect(Collectors.toMap(Opportunity::getId, Opportunity::getStage));
+
+        long nextPos = getNextPos(orgId, firstStageId);
         SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH);
         ExtOpportunityMapper batchUpdateMapper = sqlSession.getMapper(ExtOpportunityMapper.class);
         for (int i = 0; i < ids.size(); i++) {
-            batchUpdateMapper.transfer(request.getOwner(), userId, ids.get(i), System.currentTimeMillis(), nextPos + i, stageConfigList.getFirst().getId());
+            batchUpdateMapper.transfer(request.getOwner(), userId, ids.get(i), System.currentTimeMillis(), nextPos + i, firstStageId);
         }
         sqlSession.flushStatements();
         SqlSessionUtils.closeSqlSession(sqlSession, sqlSessionFactory);
 
-        // 记录日志
+        opportunityList.forEach(opportunity -> {
+            String oldStage = oldStageMap.get(opportunity.getId());
+            if (!Strings.CI.equals(oldStage, firstStageId)) {
+                opportunityStageHistoryService.add(
+                        opportunity.getId(),
+                        oldStage,
+                        firstStageId,
+                        userId,
+                        null
+                );
+            }
+        });
+
         List<LogDTO> logs = new ArrayList<>();
         opportunityList.forEach(opportunity -> {
             Customer originCustomer = new Customer();
@@ -479,6 +496,7 @@ public class OpportunityService {
         }
         opportunityMapper.deleteByIds(toDoIds);
         opportunityFieldService.deleteByResourceIds(toDoIds);
+        opportunityStageHistoryService.deleteByOpportunityIds(toDoIds);
         List<LogDTO> logs = new ArrayList<>();
         opportunityList.forEach(opportunity -> {
             LogDTO logDTO = new LogDTO(opportunity.getOrganizationId(), opportunity.getId(), userId, LogType.DELETE, LogModule.OPPORTUNITY_INDEX, opportunity.getName());
@@ -487,7 +505,6 @@ public class OpportunityService {
         });
         logService.batchAdd(logs);
 
-        // 消息通知
         opportunityList.forEach(opportunity ->
                 commonNoticeSendService.sendNotice(NotificationConstants.Module.OPPORTUNITY,
                         NotificationConstants.Event.BUSINESS_DELETED, opportunity.getName(), userId,
@@ -633,12 +650,17 @@ public class OpportunityService {
      *
      * @param request
      * @param orgId
+     * @param operatorId
      */
     @OperationLog(module = LogModule.OPPORTUNITY_INDEX, type = LogType.UPDATE, resourceId = "{#request.id}")
-    public void updateStage(OpportunityStageRequest request, String orgId) {
+    public void updateStage(OpportunityStageRequest request, String orgId, String operatorId) {
         final Opportunity oldOpportunity = opportunityMapper.selectByPrimaryKey(request.getId());
         if (oldOpportunity == null) {
             throw new GenericException(Translator.get("opportunity_not_found"));
+        }
+
+        if (Strings.CI.equals(oldOpportunity.getStage(), request.getStage())) {
+            return;
         }
 
         final List<StageConfigResponse> stageConfigList = extOpportunityStageConfigMapper.getStageConfigList(orgId);
@@ -675,6 +697,14 @@ public class OpportunityService {
         newOpportunity.setPos(nextPos);
 
         opportunityMapper.update(newOpportunity);
+
+        opportunityStageHistoryService.add(
+                request.getId(),
+                oldOpportunity.getStage(),
+                request.getStage(),
+                operatorId,
+                isFailStage ? request.getFailureReason() : null
+        );
 
         final Map<String, String> originalVal = new HashMap<>(1);
         originalVal.put("stage", stageMap.get(oldOpportunity.getStage()));
@@ -840,14 +870,15 @@ public class OpportunityService {
      * @param userId
      */
     public void sort(OpportunitySortRequest request, String userId) {
-        //拖拽节点
         Opportunity opportunity = opportunityMapper.selectByPrimaryKey(request.getDragNodeId());
         if (opportunity == null) {
             throw new GenericException(Translator.get("opportunity_not_found"));
         }
+
+        boolean stageChanged = !Strings.CI.equals(opportunity.getStage(), request.getStage());
+
         Long pos = DEFAULT_POS;
         if (StringUtils.isNotBlank(request.getDropNodeId())) {
-            //放入节点
             Opportunity dropNode = opportunityMapper.selectByPrimaryKey(request.getDropNodeId());
             pos = dropNode.getPos();
             if (request.getDropPosition() == -1) {
@@ -866,6 +897,16 @@ public class OpportunityService {
         dragOpportunity.setUpdateUser(userId);
         dragOpportunity.setUpdateTime(System.currentTimeMillis());
         opportunityMapper.updateById(dragOpportunity);
+
+        if (stageChanged) {
+            opportunityStageHistoryService.add(
+                    request.getDragNodeId(),
+                    opportunity.getStage(),
+                    request.getStage(),
+                    userId,
+                    null
+            );
+        }
     }
 
     public List<ChartResult> chart(ChartAnalysisRequest request, String userId, String orgId, DeptDataPermissionDTO deptDataPermission) {

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityStageHistoryService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityStageHistoryService.java
@@ -86,9 +86,9 @@ public class OpportunityStageHistoryService {
                 .map(item -> {
                     OpportunityStageHistoryResponse response =
                             BeanUtils.copyBean(new OpportunityStageHistoryResponse(), item);
-                    response.setOperatorName(getNameIgnoreCase(operatorNameMap, item.getOperator()));
-                    response.setFromStageName(getNameIgnoreCase(stageNameMap, item.getFromStage()));
-                    response.setToStageName(getNameIgnoreCase(stageNameMap, item.getToStage()));
+                    response.setOperatorName(getOperatorNameOrDefault(operatorNameMap, item.getOperator()));
+                    response.setFromStageName(getStageNameOrDefault(stageNameMap, item.getFromStage()));
+                    response.setToStageName(getStageNameOrDefault(stageNameMap, item.getToStage()));
                     if (StringUtils.isNotBlank(item.getFailureReasonId())) {
                         response.setFailureReasonName(getNameIgnoreCase(reasonNameMap, item.getFailureReasonId()));
                     }
@@ -101,6 +101,22 @@ public class OpportunityStageHistoryService {
             return null;
         }
         return nameMap.get(key);
+    }
+
+    private String getStageNameOrDefault(Map<String, String> stageNameMap, String stageId) {
+        if (StringUtils.isBlank(stageId)) {
+            return "未知阶段";
+        }
+        String name = stageNameMap.get(stageId);
+        return StringUtils.isNotBlank(name) ? name : "未知阶段";
+    }
+
+    private String getOperatorNameOrDefault(Map<String, String> operatorNameMap, String operatorId) {
+        if (StringUtils.isBlank(operatorId)) {
+            return "未知用户";
+        }
+        String name = operatorNameMap.get(operatorId);
+        return StringUtils.isNotBlank(name) ? name : "未知用户";
     }
 
     public void add(String opportunityId, String fromStage, String toStage, String operatorId, String failureReasonId) {

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityStageHistoryService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityStageHistoryService.java
@@ -64,16 +64,21 @@ public class OpportunityStageHistoryService {
             }
         }
 
-        Map<String, String> operatorNameMap = baseService.getUserNameMap(operatorIds);
+        Map<String, String> operatorNameMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        operatorNameMap.putAll(baseService.getUserNameMap(operatorIds));
 
         List<StageConfigResponse> stageConfigList = extOpportunityStageConfigMapper.getStageConfigList(orgId);
-        Map<String, String> stageNameMap = stageConfigList.stream()
-                .collect(Collectors.toMap(StageConfigResponse::getId, StageConfigResponse::getName));
+        Map<String, String> stageNameMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (StageConfigResponse config : stageConfigList) {
+            stageNameMap.put(config.getId(), config.getName());
+        }
 
-        Map<String, String> reasonNameMap = new HashMap<>();
+        Map<String, String> reasonNameMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         if (!reasonIds.isEmpty()) {
             List<Dict> dictList = dictMapper.selectByIds(new ArrayList<>(reasonIds));
-            reasonNameMap = dictList.stream().collect(Collectors.toMap(Dict::getId, Dict::getName));
+            for (Dict dict : dictList) {
+                reasonNameMap.put(dict.getId(), dict.getName());
+            }
         }
 
         return historyList
@@ -81,14 +86,21 @@ public class OpportunityStageHistoryService {
                 .map(item -> {
                     OpportunityStageHistoryResponse response =
                             BeanUtils.copyBean(new OpportunityStageHistoryResponse(), item);
-                    response.setOperatorName(operatorNameMap.get(item.getOperator()));
-                    response.setFromStageName(stageNameMap.get(item.getFromStage()));
-                    response.setToStageName(stageNameMap.get(item.getToStage()));
+                    response.setOperatorName(getNameIgnoreCase(operatorNameMap, item.getOperator()));
+                    response.setFromStageName(getNameIgnoreCase(stageNameMap, item.getFromStage()));
+                    response.setToStageName(getNameIgnoreCase(stageNameMap, item.getToStage()));
                     if (StringUtils.isNotBlank(item.getFailureReasonId())) {
-                        response.setFailureReasonName(reasonNameMap.get(item.getFailureReasonId()));
+                        response.setFailureReasonName(getNameIgnoreCase(reasonNameMap, item.getFailureReasonId()));
                     }
                     return response;
                 }).toList();
+    }
+
+    private String getNameIgnoreCase(Map<String, String> nameMap, String key) {
+        if (StringUtils.isBlank(key)) {
+            return null;
+        }
+        return nameMap.get(key);
     }
 
     public void add(String opportunityId, String fromStage, String toStage, String operatorId, String failureReasonId) {

--- a/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityStageHistoryService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/opportunity/service/OpportunityStageHistoryService.java
@@ -1,0 +1,120 @@
+package cn.cordys.crm.opportunity.service;
+
+import cn.cordys.common.dto.UserDeptDTO;
+import cn.cordys.common.service.BaseService;
+import cn.cordys.common.uid.IDGenerator;
+import cn.cordys.common.util.BeanUtils;
+import cn.cordys.crm.opportunity.domain.OpportunityStageHistory;
+import cn.cordys.crm.opportunity.dto.response.OpportunityStageHistoryResponse;
+import cn.cordys.crm.opportunity.dto.response.StageConfigResponse;
+import cn.cordys.crm.opportunity.mapper.ExtOpportunityStageConfigMapper;
+import cn.cordys.crm.system.constants.DictModule;
+import cn.cordys.crm.system.domain.Dict;
+import cn.cordys.crm.system.domain.DictConfig;
+import cn.cordys.mybatis.BaseMapper;
+import cn.cordys.mybatis.lambda.LambdaQueryWrapper;
+import jakarta.annotation.Resource;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+@Service
+@Transactional(rollbackFor = Exception.class)
+public class OpportunityStageHistoryService {
+    @Resource
+    private BaseMapper<OpportunityStageHistory> opportunityStageHistoryMapper;
+    @Resource
+    private BaseMapper<DictConfig> dictConfigMapper;
+    @Resource
+    private BaseMapper<Dict> dictMapper;
+    @Resource
+    private BaseService baseService;
+    @Resource
+    private ExtOpportunityStageConfigMapper extOpportunityStageConfigMapper;
+
+
+    public List<OpportunityStageHistoryResponse> list(String opportunityId, String orgId) {
+        LambdaQueryWrapper<OpportunityStageHistory> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(OpportunityStageHistory::getOpportunityId, opportunityId);
+        wrapper.orderByDesc(OpportunityStageHistory::getChangeTime);
+        List<OpportunityStageHistory> historyList = opportunityStageHistoryMapper.selectListByLambda(wrapper);
+        return buildListData(orgId, historyList);
+    }
+
+    private List<OpportunityStageHistoryResponse> buildListData(String orgId, List<OpportunityStageHistory> historyList) {
+        if (CollectionUtils.isEmpty(historyList)) {
+            return List.of();
+        }
+
+        Set<String> operatorIds = new HashSet<>();
+        Set<String> stageIds = new HashSet<>();
+        Set<String> reasonIds = new HashSet<>();
+
+        for (OpportunityStageHistory history : historyList) {
+            operatorIds.add(history.getOperator());
+            stageIds.add(history.getFromStage());
+            stageIds.add(history.getToStage());
+            if (StringUtils.isNotBlank(history.getFailureReasonId())) {
+                reasonIds.add(history.getFailureReasonId());
+            }
+        }
+
+        Map<String, String> operatorNameMap = baseService.getUserNameMap(operatorIds);
+
+        List<StageConfigResponse> stageConfigList = extOpportunityStageConfigMapper.getStageConfigList(orgId);
+        Map<String, String> stageNameMap = stageConfigList.stream()
+                .collect(Collectors.toMap(StageConfigResponse::getId, StageConfigResponse::getName));
+
+        Map<String, String> reasonNameMap = new HashMap<>();
+        if (!reasonIds.isEmpty()) {
+            List<Dict> dictList = dictMapper.selectByIds(new ArrayList<>(reasonIds));
+            reasonNameMap = dictList.stream().collect(Collectors.toMap(Dict::getId, Dict::getName));
+        }
+
+        return historyList
+                .stream()
+                .map(item -> {
+                    OpportunityStageHistoryResponse response =
+                            BeanUtils.copyBean(new OpportunityStageHistoryResponse(), item);
+                    response.setOperatorName(operatorNameMap.get(item.getOperator()));
+                    response.setFromStageName(stageNameMap.get(item.getFromStage()));
+                    response.setToStageName(stageNameMap.get(item.getToStage()));
+                    if (StringUtils.isNotBlank(item.getFailureReasonId())) {
+                        response.setFailureReasonName(reasonNameMap.get(item.getFailureReasonId()));
+                    }
+                    return response;
+                }).toList();
+    }
+
+    public void add(String opportunityId, String fromStage, String toStage, String operatorId, String failureReasonId) {
+        OpportunityStageHistory history = new OpportunityStageHistory();
+        history.setId(IDGenerator.nextStr());
+        history.setOpportunityId(opportunityId);
+        history.setFromStage(fromStage);
+        history.setToStage(toStage);
+        history.setChangeTime(System.currentTimeMillis());
+        history.setOperator(operatorId);
+        history.setFailureReasonId(failureReasonId);
+        opportunityStageHistoryMapper.insert(history);
+    }
+
+    public void deleteByOpportunityId(String opportunityId) {
+        LambdaQueryWrapper<OpportunityStageHistory> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(OpportunityStageHistory::getOpportunityId, opportunityId);
+        opportunityStageHistoryMapper.deleteByLambda(wrapper);
+    }
+
+    public void deleteByOpportunityIds(List<String> opportunityIds) {
+        if (CollectionUtils.isEmpty(opportunityIds)) {
+            return;
+        }
+        LambdaQueryWrapper<OpportunityStageHistory> wrapper = new LambdaQueryWrapper<>();
+        wrapper.in(OpportunityStageHistory::getOpportunityId, opportunityIds);
+        opportunityStageHistoryMapper.deleteByLambda(wrapper);
+    }
+}

--- a/frontend/packages/lib-shared/api/modules/opportunity.ts
+++ b/frontend/packages/lib-shared/api/modules/opportunity.ts
@@ -73,6 +73,7 @@ import {
   UpdateQuotationUrl,
   UpdateQuotationViewUrl,
   VoidQuotationUrl,
+  GetOptStageHistoryListUrl,
 } from '@lib/shared/api/requrls/opportunity';
 import type {
   ChartResponseDataItem,
@@ -108,6 +109,7 @@ import type {
   OpportunityItem,
   OpportunityPageQueryParams,
   OpportunityStageConfig,
+  OpportunityStageHistoryItem,
   QuotationItem,
   QuotationQueryParams,
   SaveOpportunityParams,
@@ -280,6 +282,11 @@ export default function useProductApi(CDR: CordysAxios) {
   // 获取商机阶段配置
   function getOpportunityStageConfig() {
     return CDR.get<OpportunityStageConfig>({ url: GetOpportunityStageConfigUrl }, { ignoreCancelToken: true });
+  }
+
+  // 获取商机阶段变更历史列表
+  function getOptStageHistoryList(opportunityId: string) {
+    return CDR.get<OpportunityStageHistoryItem[]>({ url: `${GetOptStageHistoryListUrl}/${opportunityId}` });
   }
 
   // 删除商机阶段
@@ -518,6 +525,7 @@ export default function useProductApi(CDR: CordysAxios) {
     sortOpportunityStage,
     addOpportunityStage,
     getOpportunityStageConfig,
+    getOptStageHistoryList,
     deleteOpportunityStage,
     generateOpportunityChart,
     getQuotationTab,

--- a/frontend/packages/lib-shared/api/requrls/opportunity.ts
+++ b/frontend/packages/lib-shared/api/requrls/opportunity.ts
@@ -80,3 +80,6 @@ export const DownloadQuotationUrl = '/opportunity/quotation/download';
 export const PreCheckOptImportUrl = '/opportunity/import/pre-check';
 export const DownloadOptTemplateUrl = '/opportunity/template/download';
 export const ImportOpportunityUrl = '/opportunity/import';
+
+// 商机阶段变更历史
+export const GetOptStageHistoryListUrl = '/opportunity/stage/history/list';

--- a/frontend/packages/lib-shared/models/opportunity.ts
+++ b/frontend/packages/lib-shared/models/opportunity.ts
@@ -188,3 +188,17 @@ export interface BatchOperationResult {
   skip?: number;
   errorMessages?: string;
 }
+
+export interface OpportunityStageHistoryItem {
+  id: string;
+  opportunityId: string;
+  fromStage: string;
+  fromStageName: string;
+  toStage: string;
+  toStageName: string;
+  changeTime: number;
+  operator: string;
+  operatorName: string;
+  failureReasonId?: string;
+  failureReasonName?: string;
+}

--- a/frontend/packages/web/src/views/opportunity/components/optOverviewDrawer.vue
+++ b/frontend/packages/web/src/views/opportunity/components/optOverviewDrawer.vue
@@ -77,6 +77,60 @@
           :source-name="titleName"
         />
       </CrmCard>
+      <CrmCard v-else-if="activeTab === 'stageHistory'" no-content-bottom-padding hide-footer>
+        <div class="p-[16px] h-full overflow-auto">
+          <n-timeline v-if="stageHistoryList.length" :horizontal="false">
+            <n-timeline-item
+              v-for="item in stageHistoryList"
+              :key="item.id"
+              :type="getTimelineType(item)"
+            >
+              <template #dot>
+                <div
+                  :class="[
+                    'w-[16px] h-[16px] rounded-full flex items-center justify-center text-white text-xs',
+                    getTimelineBgClass(item),
+                  ]"
+                >
+                  <n-icon size="12">
+                    <component :is="getTimelineIcon(item)" />
+                  </n-icon>
+                </div>
+              </template>
+              <div class="mb-[8px]">
+                <div class="flex items-center gap-[8px] mb-[4px]">
+                  <span class="text-[14px] font-medium text-[var(--text-n1)]">
+                    {{ item.fromStageName || '-' }}
+                  </span>
+                  <n-icon size="14" color="var(--text-n4)">
+                    <ArrowRightOutlined />
+                  </n-icon>
+                  <span
+                    :class="[
+                      'text-[14px] font-medium',
+                      getStageTextClass(item),
+                    ]"
+                  >
+                    {{ item.toStageName || '-' }}
+                  </span>
+                </div>
+                <div class="flex items-center gap-[8px] text-[12px] text-[var(--text-n4)]">
+                  <span>{{ item.operatorName || '-' }}</span>
+                  <span>{{ dayjs(item.changeTime).format('YYYY-MM-DD HH:mm:ss') }}</span>
+                </div>
+                <div
+                  v-if="item.failureReasonName"
+                  class="mt-[8px] p-[8px] bg-[var(--text-n9)] rounded text-[12px] text-[var(--text-n2)]"
+                >
+                  <span class="text-[var(--text-n4)]">{{ t('common.fail') }}：</span>
+                  {{ item.failureReasonName }}
+                </div>
+              </div>
+            </n-timeline-item>
+          </n-timeline>
+          <n-empty v-else :description="t('common.noData')" />
+        </div>
+      </CrmCard>
     </template>
 
     <template #transferPopContent>
@@ -86,13 +140,15 @@
 </template>
 
 <script setup lang="ts">
-  import { useMessage } from 'naive-ui';
+  import { NEmpty, NIcon, NTimeline, NTimelineItem, useMessage } from 'naive-ui';
+  import { ArrowRightOutlined, CheckCircleOutlined, CloseCircleOutlined, SyncOutlined } from '@vicons/antd';
+  import dayjs from 'dayjs';
 
   import { FormDesignKeyEnum } from '@lib/shared/enums/formDesignEnum';
   import { useI18n } from '@lib/shared/hooks/useI18n';
   import { characterLimit } from '@lib/shared/method';
   import type { CollaborationType, TransferParams } from '@lib/shared/models/customer';
-  import type { OpportunityItem, OpportunityStageConfig } from '@lib/shared/models/opportunity';
+  import type { OpportunityItem, OpportunityStageConfig, OpportunityStageHistoryItem } from '@lib/shared/models/opportunity';
   import type { FormConfig, FormViewSize } from '@lib/shared/models/system/module';
 
   import CrmCard from '@/components/pure/crm-card/index.vue';
@@ -106,7 +162,7 @@
   import CrmWorkflowCard from '@/components/business/crm-workflow-card/index.vue';
   import quotationTable from './quotation/quotationTable.vue';
 
-  import { deleteOpt, getOpportunityStageConfig, transferOpt, updateOptStage } from '@/api/modules';
+  import { deleteOpt, getOpportunityStageConfig, getOptStageHistoryList, transferOpt, updateOptStage } from '@/api/modules';
   import { defaultTransferForm } from '@/config/opportunity';
   import useModal from '@/hooks/useModal';
   import { hasAllPermission, hasAnyPermission } from '@/utils/permission';
@@ -139,12 +195,27 @@
   });
 
   const stageConfig = ref<OpportunityStageConfig>();
+  const stageHistoryList = ref<OpportunityStageHistoryItem[]>([]);
+
   async function initStageConfig() {
     try {
       stageConfig.value = await getOpportunityStageConfig();
     } catch (error) {
-      // eslint-disable-next-line no-console
       console.log(error);
+    }
+  }
+
+  async function loadStageHistory() {
+    if (!sourceId.value) {
+      stageHistoryList.value = [];
+      return;
+    }
+    try {
+      const res = await getOptStageHistoryList(sourceId.value);
+      stageHistoryList.value = res || [];
+    } catch (error) {
+      console.log(error);
+      stageHistoryList.value = [];
     }
   }
 
@@ -160,6 +231,66 @@
   const isFail = computed(
     () => currentStatus.value === stageConfig.value?.stageConfigList.find((e) => e.type === 'END' && e.rate === '0')?.id
   );
+
+  function getTimelineType(item: OpportunityStageHistoryItem): 'success' | 'error' | 'default' {
+    const endStage = stageConfig.value?.stageConfigList.find(
+      (s) => s.type === 'END' && s.id === item.toStage
+    );
+    if (endStage) {
+      if (endStage.rate === '100') {
+        return 'success';
+      }
+      if (endStage.rate === '0') {
+        return 'error';
+      }
+    }
+    return 'default';
+  }
+
+  function getTimelineBgClass(item: OpportunityStageHistoryItem): string {
+    const endStage = stageConfig.value?.stageConfigList.find(
+      (s) => s.type === 'END' && s.id === item.toStage
+    );
+    if (endStage) {
+      if (endStage.rate === '100') {
+        return 'bg-[var(--success-6)]';
+      }
+      if (endStage.rate === '0') {
+        return 'bg-[var(--error-6)]';
+      }
+    }
+    return 'bg-[var(--primary-6)]';
+  }
+
+  function getStageTextClass(item: OpportunityStageHistoryItem): string {
+    const endStage = stageConfig.value?.stageConfigList.find(
+      (s) => s.type === 'END' && s.id === item.toStage
+    );
+    if (endStage) {
+      if (endStage.rate === '100') {
+        return 'text-[var(--success-6)]';
+      }
+      if (endStage.rate === '0') {
+        return 'text-[var(--error-6)]';
+      }
+    }
+    return 'text-[var(--primary-6)]';
+  }
+
+  function getTimelineIcon(item: OpportunityStageHistoryItem) {
+    const endStage = stageConfig.value?.stageConfigList.find(
+      (s) => s.type === 'END' && s.id === item.toStage
+    );
+    if (endStage) {
+      if (endStage.rate === '100') {
+        return CheckCircleOutlined;
+      }
+      if (endStage.rate === '0') {
+        return CloseCircleOutlined;
+      }
+    }
+    return SyncOutlined;
+  }
 
   const transferLoading = ref(false);
 
@@ -243,6 +374,11 @@
       enable: true,
       permission: ['OPPORTUNITY_QUOTATION:READ'],
     },
+    {
+      name: 'stageHistory',
+      tab: '阶段变更历史',
+      enable: true,
+    },
   ];
 
   const titleName = ref('');
@@ -313,6 +449,7 @@
   function refreshList() {
     refreshKey.value += 1;
     emit('refresh');
+    loadStageHistory();
   }
 
   const formViewSize = ref<FormViewSize>('large');
@@ -324,9 +461,7 @@
   ) {
     if (detail) {
       const { customerName, customerId, name, stage, failureReason } = detail;
-      // 商机阶段
       currentStatus.value = stage;
-      // 用于回显跟进类型、商机、商机对应客户
       titleName.value = _sourceName || '';
       subTitleName.value = customerName;
       lastFailureReason.value = failureReason;
@@ -345,6 +480,7 @@
     (val) => {
       if (val) {
         initStageConfig();
+        loadStageHistory();
       }
     }
   );


### PR DESCRIPTION
refactor(service): 统一处理用户和阶段名称的默认值

为OpportunityStageHistoryService、ClueOwnerHistoryService和CustomerOwnerHistoryService添加默认值处理方法

使用TreeMap确保名称映射的键不区分大小写

当用户ID或阶段ID为空或未找到时返回"未知用户"或"未知阶段"