### PR TITLE
fix: custom form table page pagination

### DIFF
--- a/frontend/packages/web/src/views/customForm/components/formTable.vue
+++ b/frontend/packages/web/src/views/customForm/components/formTable.vue
@@ -409,6 +409,7 @@
   async function init(val: string) {
     checkedRowKeys.value = [];
     keyword.value = '';
+    propsRes.value.tableKey = val;
     await initFormConfig(props.readonly, operationColumn.value);
     tableAdvanceFilterRef.value?.clearFilter();
     setLoadListParams({ customFormId: val });


### PR DESCRIPTION
【【自定义表单】资源列表页码分页-点击页码/跳转至/左右翻页-列表数据不符】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001071115