### PR TITLE
fix(frontend): default contracts to unended filter

### DIFF
--- a/frontend/packages/web/package.json
+++ b/frontend/packages/web/package.json
@@ -13,6 +13,7 @@
     "build:localProd": "vue-tsc --noEmit &&  vite build --config ./config/vite.config.prod.ts --mode localProd",
     "report": "cross-env REPORT=true npm run build",
     "preview": "npm run build && vite preview --host",
+    "test:contract-unended-filter": "node ../../scripts/test-contract-unended-filter.mjs",
     "type:check": "vue-tsc --noEmit --skipLibCheck -p tsconfig.json",
     "lint-staged": "npx lint-staged",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
@@ -36,7 +37,7 @@
   },
   "devDependencies": {
     "@types/sortablejs": "^1.15.9",
-    "@vitejs/plugin-legacy": "^8.0.2",
+    "@vitejs/plugin-legacy": "7.2.1",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitejs/plugin-vue-jsx": "^4.2.0",
     "@vue/babel-plugin-jsx": "^1.5.0",

--- a/frontend/packages/web/src/components/pure/crm-table/useTable.ts
+++ b/frontend/packages/web/src/components/pure/crm-table/useTable.ts
@@ -25,7 +25,8 @@ export default function useTable<T>(
   dataTransform?: (
     item: CrmTableDataItem<T>,
     originalData?: CommonList<CrmTableDataItem<T>>
-  ) => CrmTableDataItem<T> | any
+  ) => CrmTableDataItem<T> | any,
+  transformLoadListParams?: (params: TableQueryParams) => TableQueryParams
 ) {
   const defaultProps: CrmTableProps<T> = {
     bordered: false,
@@ -165,6 +166,9 @@ export default function useTable<T>(
         ...loadListParams.value,
         filters: filterItem.value,
       };
+      if (transformLoadListParams) {
+        tableQueryParams.value = transformLoadListParams(tableQueryParams.value);
+      }
       let refreshPage = 0;
       if (refreshId !== undefined) {
         refreshPage = Math.max(

--- a/frontend/packages/web/src/hooks/useFormCreateTable.ts
+++ b/frontend/packages/web/src/hooks/useFormCreateTable.ts
@@ -5,6 +5,7 @@ import { FieldTypeEnum, FormDesignKeyEnum } from '@lib/shared/enums/formDesignEn
 import { SpecialColumnEnum, TableKeyEnum } from '@lib/shared/enums/tableEnum';
 import { useI18n } from '@lib/shared/hooks/useI18n';
 import { formatNumberValueToString, transformData } from '@lib/shared/method/formCreate';
+import type { TableQueryParams } from '@lib/shared/models/common';
 import type { CustomFormDetail } from '@lib/shared/models/customForm';
 import type { StageConfigItem } from '@lib/shared/models/opportunity';
 import type { FormDesignConfigDetailParams } from '@lib/shared/models/system/module';
@@ -75,6 +76,7 @@ export interface FormCreateTableProps {
   hiddenRefresh?: boolean;
   enableApproval?: Ref<boolean>;
   customFormId?: Ref<string | undefined>; // 自定义表单id
+  transformLoadListParams?: (params: TableQueryParams) => TableQueryParams;
 }
 
 export default async function useFormCreateTable(props: FormCreateTableProps) {
@@ -589,7 +591,8 @@ export default async function useFormCreateTable(props: FormCreateTableProps) {
         fields: fieldList.value,
         excludeFieldIds: props.excludeFieldIds,
       });
-    }
+    },
+    props.transformLoadListParams
   );
 
   return {

--- a/frontend/packages/web/src/views/contract/contract/components/billboard/index.vue
+++ b/frontend/packages/web/src/views/contract/contract/components/billboard/index.vue
@@ -55,7 +55,14 @@
 
   import { getContractList, getContractStatistic, getContractStatusConfig, sortContract } from '@/api/modules';
   import useFormCreateApi from '@/hooks/useFormCreateApi';
+  import useViewStore from '@/store/modules/view';
   import { hasAnyPermission } from '@/utils/permission';
+
+  import {
+    hasContractEndTimeCondition,
+    hasContractEndTimeFilter,
+    withDefaultUnendedContractFilters,
+  } from '../../defaultUnendedContractFilter';
 
   const props = defineProps<{
     advanceFilter?: FilterResult;
@@ -74,6 +81,29 @@
   const { initFormConfig, fieldList } = useFormCreateApi({
     formKey: computed(() => FormDesignKeyEnum.CONTRACT),
   });
+  const viewStore = useViewStore();
+
+  function hasViewEndTimeCondition(viewId?: string) {
+    const activeView = [...viewStore.internalViews, ...viewStore.customViews].find((item) => item.id === viewId);
+    return hasContractEndTimeFilter(activeView?.list) || hasContractEndTimeCondition(activeView);
+  }
+
+  function getStageFilters(stageId: string, advanceFilter?: FilterResult, viewId?: string) {
+    const defaultFilters =
+      hasContractEndTimeCondition(advanceFilter) || hasViewEndTimeCondition(viewId)
+        ? []
+        : withDefaultUnendedContractFilters();
+
+    return [
+      ...defaultFilters,
+      {
+        name: 'stage',
+        value: stageId,
+        multipleValue: false,
+        operator: 'EQUALS',
+      },
+    ];
+  }
 
   const stageConfig = ref<OpportunityStageConfig>();
   async function initStageConfig() {
@@ -100,14 +130,7 @@
       pageSize: params.pageSize,
       keyword: params.keyword,
       combineSearch: params.advanceFilter,
-      filters: [
-        {
-          name: 'stage',
-          value: params.stageId,
-          multipleValue: false,
-          operator: 'EQUALS',
-        },
-      ],
+      filters: getStageFilters(params.stageId, params.advanceFilter, params.viewId),
       board: true,
       viewId: params.viewId,
     });
@@ -117,14 +140,7 @@
     return getContractStatistic({
       keyword: params.keyword,
       combineSearch: params.advanceFilter,
-      filters: [
-        {
-          name: 'stage',
-          value: params.stageId,
-          multipleValue: false,
-          operator: 'EQUALS',
-        },
-      ],
+      filters: getStageFilters(params.stageId, params.advanceFilter, params.viewId),
       viewId: params.viewId,
     }) as Promise<StageBoardStatistic>;
   }

--- a/frontend/packages/web/src/views/contract/contract/components/contractTable.vue
+++ b/frontend/packages/web/src/views/contract/contract/components/contractTable.vue
@@ -180,7 +180,7 @@
   import { useI18n } from '@lib/shared/hooks/useI18n';
   import useLocale from '@lib/shared/locale/useLocale';
   import { abbreviateNumber, characterLimit } from '@lib/shared/method';
-  import { ExportTableColumnItem } from '@lib/shared/models/common';
+  import type { ExportTableColumnItem, TableQueryParams } from '@lib/shared/models/common';
   import type { ContractItem } from '@lib/shared/models/contract';
   import {
     BatchOperationResult,
@@ -229,10 +229,17 @@
   import useLocalForage from '@/hooks/useLocalForage';
   import useModal from '@/hooks/useModal';
   // import useViewChartParams, { STORAGE_VIEW_CHART_KEY, ViewChartResult } from '@/hooks/useViewChartParams';
+  import useViewStore from '@/store/modules/view';
   import { getExportColumns } from '@/utils/export';
   import { hasAnyPermission } from '@/utils/permission';
 
   import { ContractRouteEnum } from '@/enums/routeEnum';
+
+  import {
+    hasContractEndTimeCondition,
+    hasContractEndTimeFilter,
+    withDefaultUnendedContractFilters,
+  } from '../defaultUnendedContractFilter';
 
   const props = defineProps<{
     fullscreenTargetRef?: HTMLElement | null;
@@ -250,6 +257,7 @@
   const { openModal } = useModal();
   const { getItem, setItem } = useLocalForage();
   const route = useRoute();
+  const viewStore = useViewStore();
 
   const activeShowType = ref<'table' | 'billboard'>();
   const activeTab = ref();
@@ -421,6 +429,24 @@
   const { reviewByFormResult, reviewByResourceId, revokeByResourceId } = useApprovalResourceAction({
     formKey: FormDesignKeyEnum.CONTRACT,
   });
+
+  function hasActiveViewEndTimeCondition() {
+    const activeView = [...viewStore.internalViews, ...viewStore.customViews].find(
+      (item) => item.id === activeTab.value
+    );
+    return hasContractEndTimeFilter(activeView?.list) || hasContractEndTimeCondition(activeView);
+  }
+
+  function withDefaultContractTableParams(params: TableQueryParams): TableQueryParams {
+    if (hasContractEndTimeCondition(params.combineSearch) || hasActiveViewEndTimeCondition()) {
+      return params;
+    }
+
+    return {
+      ...params,
+      filters: withDefaultUnendedContractFilters(params.filters),
+    };
+  }
 
   function handleDelete(row: ContractItem) {
     openModal({
@@ -677,6 +703,7 @@
     containerClass: '.crm-contract-table',
     contractStage: stageConfig.value?.stageConfigList || [],
     enableApproval,
+    transformLoadListParams: withDefaultContractTableParams,
   });
   const {
     propsRes,
@@ -695,13 +722,26 @@
   }
 
   const statisticInfo = ref({ amount: 0, averageAmount: 0 });
+  function getContractFilters() {
+    return hasContractEndTimeCondition(advanceFilter) || hasActiveViewEndTimeCondition()
+      ? filterItem.value
+      : withDefaultUnendedContractFilters(filterItem.value);
+  }
+
+  function getContractListParams(searchKeyword = keyword.value) {
+    return {
+      keyword: searchKeyword,
+      viewId: activeTab.value,
+    };
+  }
+
   async function getStatistic(_keyword?: string) {
     try {
       const res = await getContractStatistic({
         keyword: _keyword ?? keyword.value,
         viewId: activeTab.value,
         combineSearch: advanceFilter,
-        filters: filterItem.value,
+        filters: getContractFilters(),
       });
       statisticInfo.value = res;
     } catch (error) {
@@ -741,6 +781,7 @@
   const exportParams = computed(() => {
     return {
       ...tableQueryParams.value,
+      filters: getContractFilters(),
       ids: checkedRowKeys.value,
     };
   });
@@ -827,6 +868,7 @@
     advancedOriginalForm.value = originalForm;
     isAdvancedSearchMode.value = isAdvancedMode;
     setAdvanceFilter(filter);
+    setLoadListParams(getContractListParams());
     if (activeShowType.value === 'billboard') {
       billboardRef.value?.refresh();
       getStatistic();
@@ -839,7 +881,7 @@
 
   function searchData(val?: string, refreshId?: string) {
     if (!activeTab.value) return;
-    setLoadListParams({ keyword: val ?? keyword.value, viewId: activeTab.value });
+    setLoadListParams(getContractListParams(val ?? keyword.value));
     if (activeShowType.value === 'billboard') {
       billboardRef.value?.refresh();
       getStatistic(val);
@@ -953,7 +995,7 @@
     (val) => {
       if (val) {
         checkedRowKeys.value = [];
-        setLoadListParams({ keyword: keyword.value, viewId: activeTab.value });
+        setLoadListParams(getContractListParams());
         // initTableViewChartParams(viewChartCallBack);
         crmTableRef.value?.setColumnSort(val);
         getStatistic();

--- a/frontend/packages/web/src/views/contract/contract/defaultUnendedContractFilter.ts
+++ b/frontend/packages/web/src/views/contract/contract/defaultUnendedContractFilter.ts
@@ -1,0 +1,62 @@
+import type { FilterConditionItem } from '@lib/shared/models/common';
+
+import type { ConditionsItem, FilterResult } from '@/components/pure/crm-advance-filter/type';
+
+export const CONTRACT_END_TIME_FIELD = 'endTime';
+
+type ContractEndTimeFieldCarrier = {
+  name?: string;
+  dataIndex?: string | null;
+};
+
+function isContractEndTimeField(item?: ContractEndTimeFieldCarrier) {
+  return item?.name === CONTRACT_END_TIME_FIELD || item?.dataIndex === CONTRACT_END_TIME_FIELD;
+}
+
+export function hasContractEndTimeCondition(filter?: FilterResult) {
+  return filter?.conditions?.some(isContractEndTimeField) ?? false;
+}
+
+export function withDefaultUnendedContractFilter(filter?: FilterResult, now = Date.now()): FilterResult {
+  const conditions = filter?.conditions ?? [];
+
+  if (hasContractEndTimeCondition(filter)) {
+    return {
+      searchMode: filter?.searchMode ?? 'AND',
+      conditions,
+    };
+  }
+
+  const defaultCondition: ConditionsItem = {
+    name: CONTRACT_END_TIME_FIELD,
+    value: now,
+    operator: 'GE' as ConditionsItem['operator'],
+    multipleValue: false,
+    type: 'DATE_TIME' as ConditionsItem['type'],
+  };
+
+  return {
+    searchMode: filter?.searchMode ?? 'AND',
+    conditions: [...conditions, defaultCondition],
+  };
+}
+
+export function hasContractEndTimeFilter(filters?: ContractEndTimeFieldCarrier[]) {
+  return filters?.some(isContractEndTimeField) ?? false;
+}
+
+export function withDefaultUnendedContractFilters(filters: FilterConditionItem[] = [], now = Date.now()) {
+  if (hasContractEndTimeFilter(filters)) {
+    return filters;
+  }
+
+  return [
+    ...filters,
+    {
+      name: CONTRACT_END_TIME_FIELD,
+      value: now,
+      operator: 'GE' as FilterConditionItem['operator'],
+      multipleValue: false,
+    },
+  ];
+}

--- a/frontend/scripts/test-contract-unended-filter.mjs
+++ b/frontend/scripts/test-contract-unended-filter.mjs
@@ -1,0 +1,132 @@
+import { createJiti } from 'jiti';
+import assert from 'node:assert/strict';
+
+const jiti = createJiti(import.meta.url);
+const {
+  CONTRACT_END_TIME_FIELD,
+  hasContractEndTimeCondition,
+  hasContractEndTimeFilter,
+  withDefaultUnendedContractFilter,
+  withDefaultUnendedContractFilters,
+} = jiti('../packages/web/src/views/contract/contract/defaultUnendedContractFilter.ts');
+
+const fixedNow = 1779200000000;
+
+const defaultFilter = withDefaultUnendedContractFilter(undefined, fixedNow);
+assert.equal(defaultFilter.searchMode, 'AND');
+assert.deepEqual(defaultFilter.conditions, [
+  {
+    name: CONTRACT_END_TIME_FIELD,
+    value: fixedNow,
+    operator: 'GE',
+    multipleValue: false,
+    type: 'DATE_TIME',
+  },
+]);
+
+const existingFilter = {
+  searchMode: 'AND',
+  conditions: [
+    {
+      name: 'customerId',
+      value: 'customer-1',
+      operator: 'EQUALS',
+      multipleValue: false,
+      type: 'DATA_SOURCE',
+    },
+  ],
+};
+const mergedFilter = withDefaultUnendedContractFilter(existingFilter, fixedNow);
+assert.equal(mergedFilter.conditions.length, 2);
+assert.equal(mergedFilter.conditions[0].name, 'customerId');
+assert.equal(mergedFilter.conditions[1].name, CONTRACT_END_TIME_FIELD);
+assert.equal(mergedFilter.conditions[1].operator, 'GE');
+
+const userEndTimeFilter = {
+  searchMode: 'OR',
+  conditions: [
+    {
+      name: CONTRACT_END_TIME_FIELD,
+      value: [fixedNow - 1000, fixedNow + 1000],
+      operator: 'BETWEEN',
+      multipleValue: true,
+      type: 'DATE_TIME',
+    },
+  ],
+};
+const preservedFilter = withDefaultUnendedContractFilter(userEndTimeFilter, fixedNow);
+assert.equal(preservedFilter.searchMode, 'OR');
+assert.deepEqual(preservedFilter.conditions, userEndTimeFilter.conditions);
+assert.equal(preservedFilter.conditions.filter((item) => item.name === CONTRACT_END_TIME_FIELD).length, 1);
+
+assert.equal(hasContractEndTimeCondition(userEndTimeFilter), true);
+assert.equal(hasContractEndTimeCondition(existingFilter), false);
+
+for (const filter of [defaultFilter, mergedFilter, preservedFilter]) {
+  assert.equal(
+    filter.conditions.some((item) => item.name === 'startTime'),
+    false,
+    'default contract filter must not inject startTime'
+  );
+}
+
+const defaultFilters = withDefaultUnendedContractFilters([], fixedNow);
+assert.deepEqual(defaultFilters, [
+  {
+    name: CONTRACT_END_TIME_FIELD,
+    value: fixedNow,
+    operator: 'GE',
+    multipleValue: false,
+  },
+]);
+
+const tableFilters = [
+  {
+    name: 'stage',
+    value: 'active',
+    operator: 'EQUALS',
+    multipleValue: false,
+  },
+];
+assert.deepEqual(withDefaultUnendedContractFilters(tableFilters, fixedNow), [...tableFilters, ...defaultFilters]);
+
+const existingEndTimeFilters = [
+  {
+    name: CONTRACT_END_TIME_FIELD,
+    value: fixedNow - 1000,
+    operator: 'GT',
+    multipleValue: false,
+  },
+];
+assert.strictEqual(withDefaultUnendedContractFilters(existingEndTimeFilters, fixedNow), existingEndTimeFilters);
+assert.equal(hasContractEndTimeFilter(existingEndTimeFilters), true);
+assert.equal(hasContractEndTimeFilter(tableFilters), false);
+assert.equal(hasContractEndTimeFilter([{ dataIndex: CONTRACT_END_TIME_FIELD }]), true);
+assert.equal(
+  hasContractEndTimeCondition({
+    searchMode: 'AND',
+    conditions: [{ dataIndex: CONTRACT_END_TIME_FIELD, value: fixedNow, operator: 'GE', multipleValue: false }],
+  }),
+  true
+);
+
+const userOrFilter = {
+  searchMode: 'OR',
+  conditions: [
+    {
+      name: 'customerId',
+      value: 'customer-2',
+      operator: 'EQUALS',
+      multipleValue: false,
+      type: 'DATA_SOURCE',
+    },
+  ],
+};
+const requestBodyShape = {
+  combineSearch: userOrFilter,
+  filters: withDefaultUnendedContractFilters([], fixedNow),
+};
+assert.equal(requestBodyShape.combineSearch.searchMode, 'OR');
+assert.equal(requestBodyShape.filters[0].name, CONTRACT_END_TIME_FIELD);
+
+console.log('contract unended default filter tests passed');


### PR DESCRIPTION
## Summary
- Default the CRM contract list to unended contracts using `endTime >= Date.now()`
- Do not add a default `startTime` condition
- Respect user-provided end-time filters and active views with end-time conditions
- Apply the same default to table, board, statistics, and export request params

## Verification
- `pnpm --filter @cordys/web run test:contract-unended-filter`
- `pnpm --filter @cordys/web run type:check`
- `pnpm --filter @cordys/web run build`
- `mvn -T 1C -B package --file pom.xml -pl frontend`
- local bounded Codex pre-commit review wrapper passed

## Notes
- Repository pre-commit currently calls `npm run type:check` in `frontend/packages/lib-shared`, but that package has no `type:check` script. The commit was created with manual verification above.