### PR TITLE
fix: follow up record and plan comment log

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/BaseCommentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/BaseCommentService.java
@@ -1,5 +1,7 @@
 package cn.cordys.crm.follow.service;
 
+import cn.cordys.aspectj.context.OperationLogContext;
+import cn.cordys.aspectj.dto.LogContextInfo;
 import cn.cordys.common.exception.GenericException;
 import cn.cordys.common.pager.PageUtils;
 import cn.cordys.common.pager.PagerWithCommentCount;
@@ -59,7 +61,7 @@ public abstract class BaseCommentService<C extends Comment> {
 
     protected abstract void updateResourceCommentCount(String resourceId, String orgId, long commentCount);
 
-    protected abstract CommentResourceInfo getResource(String resourceId, String orgId, String userId);
+    protected abstract CommentResourceInfo getNoticeResource(String resourceId, String orgId);
 
     public PagerWithCommentCount<List<CommentResponse>> page(CommentPageRequest request, String orgId) {
         Page<Object> page = PageHelper.startPage(request.getCurrent(), request.getPageSize());
@@ -98,28 +100,49 @@ public abstract class BaseCommentService<C extends Comment> {
         updateCommentCount(request.getResourceId(), orgId);
 
         sendNotifications(request.getResourceId(), request.getReplyToUserId(), request.getMentionedUserIds(), userId, orgId);
+
+        // 设置日志上下文
+        OperationLogContext.setContext(
+                LogContextInfo.builder()
+                        .resourceId(comment.getResourceId())
+                        .resourceName(Translator.get("permission.add") + Translator.get("log.comment"))
+                        .modifiedValue(Map.of("comment", comment.getContent()))
+                        .build()
+        );
         return comment;
     }
 
     private void sendNotifications(String resourceId, String replyToUserId, List<String> mentionedUserIds, String userId, String orgId) {
         List<String> noticeMentionedUserIds = mergeNotificationUsers(mentionedUserIds, replyToUserId);
-        CommentResourceInfo resourceInfo = getResource(resourceId, orgId, userId);
+        CommentResourceInfo resourceInfo = getNoticeResource(resourceId, orgId);
         sendNotifications(resourceInfo, resourceId, noticeMentionedUserIds, userId, orgId);
     }
 
     public C update(CommentUpdateRequest request, String userId, String orgId) {
         C comment = getAndCheckOwnComment(request.getId(), userId, orgId);
+        String originContent = comment.getContent();
         comment.setContent(request.getContent());
         comment.setUpdateUser(userId);
         comment.setUpdateTime(System.currentTimeMillis());
         getCommentMapper().update(comment);
 
         sendNotifications(comment.getResourceId(), comment.getReplyToUserId(), request.getMentionedUserIds(), userId, orgId);
+
+        // 设置日志上下文
+        OperationLogContext.setContext(
+                LogContextInfo.builder()
+                        .resourceId(comment.getResourceId())
+                        .resourceName(Translator.get("permission.update") + Translator.get("log.comment"))
+                        .originalValue(Map.of("comment", originContent))
+                        .modifiedValue(Map.of("comment", comment.getContent()))
+                        .build()
+        );
         return comment;
     }
 
     public void delete(String id, String userId, String orgId) {
         C comment = getAndCheckOwnComment(id, userId, orgId);
+        String originContent = comment.getContent();
         List<String> ids = new ArrayList<>();
         ids.add(id);
 
@@ -130,6 +153,15 @@ public abstract class BaseCommentService<C extends Comment> {
 
         getCommentMapper().deleteByIds(ids);
         updateCommentCount(comment.getResourceId(), orgId);
+
+        // 设置日志上下文
+        OperationLogContext.setContext(
+                LogContextInfo.builder()
+                        .resourceId(comment.getResourceId())
+                        .resourceName(Translator.get("permission.delete") + Translator.get("log.comment"))
+                        .originalValue(Map.of("comment", originContent))
+                        .build()
+        );
     }
 
     private void updateCommentCount(String resourceId, String orgId) {

--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpPlanCommentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpPlanCommentService.java
@@ -38,22 +38,19 @@ public class FollowUpPlanCommentService extends BaseCommentService<FollowUpPlanC
     }
 
     @Override
-    @OperationLog(module = LogModule.FOLLOW_UP_PLAN, type = LogType.ADD,
-            resourceId = "{#request.targetId}", resourceName = "{#request.content}")
+    @OperationLog(module = LogModule.FOLLOW_UP_PLAN, type = LogType.UPDATE)
     public FollowUpPlanComment add(CommentAddRequest request, String userId, String orgId) {
         return super.add(request, userId, orgId);
     }
 
     @Override
-    @OperationLog(module = LogModule.FOLLOW_UP_PLAN, type = LogType.UPDATE,
-            resourceId = "{#request.id}", resourceName = "{#request.content}")
+    @OperationLog(module = LogModule.FOLLOW_UP_PLAN, type = LogType.UPDATE)
     public FollowUpPlanComment update(CommentUpdateRequest request, String userId, String orgId) {
         return super.update(request, userId, orgId);
     }
 
     @Override
-    @OperationLog(module = LogModule.FOLLOW_UP_PLAN, type = LogType.DELETE,
-            resourceId = "{#id}", resourceName = "{#id}")
+    @OperationLog(module = LogModule.FOLLOW_UP_PLAN, type = LogType.UPDATE)
     public void delete(String id, String userId, String orgId) {
         super.delete(id, userId, orgId);
     }
@@ -94,7 +91,7 @@ public class FollowUpPlanCommentService extends BaseCommentService<FollowUpPlanC
     }
 
     @Override
-    protected CommentResourceInfo getResource(String resourceId, String orgId, String userId) {
+    protected CommentResourceInfo getNoticeResource(String resourceId, String orgId) {
         FollowUpPlan plan = planMapper.selectByPrimaryKey(resourceId);
         if (plan == null || !Objects.equals(plan.getOrganizationId(), orgId)) {
             throw new GenericException(Translator.get("follow.comment.target_not_found"));

--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpPlanLogService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpPlanLogService.java
@@ -69,6 +69,10 @@ public class FollowUpPlanLogService extends BaseModuleLogService {
                 continue;
             }
 
+            if (Strings.CS.equals(differ.getColumn(), "comment")) {
+                differ.setColumnName(Translator.get("log.comment"));
+                continue;
+            }
 
             if (Strings.CS.equals(differ.getColumn(), BusinessModuleField.FOLLOW_PLAN_OPPORTUNITY.getBusinessKey())) {
                 setOpportunityName(differ);

--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpRecordCommentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpRecordCommentService.java
@@ -38,22 +38,19 @@ public class FollowUpRecordCommentService extends BaseCommentService<FollowUpRec
     }
 
     @Override
-    @OperationLog(module = LogModule.FOLLOW_UP_RECORD, type = LogType.ADD,
-            resourceId = "{#request.targetId}", resourceName = "{#request.content}")
+    @OperationLog(module = LogModule.FOLLOW_UP_RECORD, type = LogType.UPDATE)
     public FollowUpRecordComment add(CommentAddRequest request, String userId, String orgId) {
         return super.add(request, userId, orgId);
     }
 
     @Override
-    @OperationLog(module = LogModule.FOLLOW_UP_RECORD, type = LogType.UPDATE,
-            resourceId = "{#request.id}", resourceName = "{#request.content}")
+    @OperationLog(module = LogModule.FOLLOW_UP_RECORD, type = LogType.UPDATE)
     public FollowUpRecordComment update(CommentUpdateRequest request, String userId, String orgId) {
         return super.update(request, userId, orgId);
     }
 
     @Override
-    @OperationLog(module = LogModule.FOLLOW_UP_RECORD, type = LogType.DELETE,
-            resourceId = "{#id}", resourceName = "{#id}")
+    @OperationLog(module = LogModule.FOLLOW_UP_RECORD, type = LogType.UPDATE)
     public void delete(String id, String userId, String orgId) {
         super.delete(id, userId, orgId);
     }
@@ -94,7 +91,7 @@ public class FollowUpRecordCommentService extends BaseCommentService<FollowUpRec
     }
 
     @Override
-    protected CommentResourceInfo getResource(String resourceId, String orgId, String userId) {
+    protected CommentResourceInfo getNoticeResource(String resourceId, String orgId) {
         FollowUpRecord record = recordMapper.selectByPrimaryKey(resourceId);
         if (record == null || !Objects.equals(record.getOrganizationId(), orgId)) {
             throw new GenericException(Translator.get("follow.comment.target_not_found"));

--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpRecordLogService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpRecordLogService.java
@@ -63,6 +63,11 @@ public class FollowUpRecordLogService extends BaseModuleLogService {
                 continue;
             }
 
+            if (Strings.CS.equals(differ.getColumn(), "comment")) {
+                differ.setColumnName(Translator.get("log.comment"));
+                continue;
+            }
+
             if (Strings.CS.equals(differ.getColumn(), BusinessModuleField.FOLLOW_RECORD_OPPORTUNITY.getBusinessKey())) {
                 setOpportunityName(differ);
             }

--- a/backend/crm/src/main/resources/i18n/cordys-crm_en_US.properties
+++ b/backend/crm/src/main/resources/i18n/cordys-crm_en_US.properties
@@ -1105,3 +1105,4 @@ message.follow_up_record_comment_mentioned_text=[Comment Reminder] ${OPERATOR} a
 follow.comment.not_found=The comment does not exist
 follow.comment.target_not_found=The follow-up plan or record does not exist
 follow.comment.only_creator=Only the comment creator can edit or delete it
+log.comment=comment

--- a/backend/crm/src/main/resources/i18n/cordys-crm_zh_CN.properties
+++ b/backend/crm/src/main/resources/i18n/cordys-crm_zh_CN.properties
@@ -1105,3 +1105,4 @@ message.follow_up_record_comment_mentioned_text=【评论提醒】${OPERATOR} �
 follow.comment.not_found=评论不存在
 follow.comment.target_not_found=跟进计划或跟进记录不存在
 follow.comment.only_creator=只能编辑或删除自己创建的评论
+log.comment=评论


### PR DESCRIPTION
fix: follow up record and plan comment log  --bug=1073804@tapd-34675357 --user=陈建星 【跟进记录/计划】添加评论时未产生对应的操作日志而且更新评论时操作日志详情空白 https://www.tapd.cn/34675357/s/2017032 