### PR TITLE
fix: follow up record and plan comment notice classify

### DIFF
--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/BaseCommentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/BaseCommentService.java
@@ -2,6 +2,7 @@ package cn.cordys.crm.follow.service;
 
 import cn.cordys.aspectj.context.OperationLogContext;
 import cn.cordys.aspectj.dto.LogContextInfo;
+import cn.cordys.common.constants.ModuleKey;
 import cn.cordys.common.exception.GenericException;
 import cn.cordys.common.pager.PageUtils;
 import cn.cordys.common.pager.PagerWithCommentCount;
@@ -19,6 +20,8 @@ import cn.cordys.crm.follow.dto.response.CommentResponse;
 import cn.cordys.crm.follow.dto.response.CommentMentionUserResponse;
 import cn.cordys.crm.follow.mapper.ExtCommentMapper;
 import cn.cordys.crm.opportunity.domain.Opportunity;
+import cn.cordys.crm.system.domain.MessageTask;
+import cn.cordys.crm.system.mapper.ExtMessageTaskMapper;
 import cn.cordys.crm.system.notice.CommonNoticeSendService;
 import cn.cordys.mybatis.BaseMapper;
 import cn.cordys.mybatis.lambda.LambdaQueryWrapper;
@@ -48,6 +51,8 @@ public abstract class BaseCommentService<C extends Comment> {
     private ExtCommentMapper extCommentMapper;
     @Resource
     private CommonNoticeSendService commonNoticeSendService;
+    @Resource
+    private ExtMessageTaskMapper extMessageTaskMapper;
 
     protected abstract BaseMapper<C> getCommentMapper();
 
@@ -57,11 +62,9 @@ public abstract class BaseCommentService<C extends Comment> {
 
     protected abstract String getCommentMentionTable();
 
-    protected abstract String getNotificationModule();
+    protected abstract String getCommentAddedEvent(String resourceId);
 
-    protected abstract String getCommentAddedEvent();
-
-    protected abstract String getCommentMentionedEvent();
+    protected abstract String getCommentMentionedEvent(String resourceId);
 
     protected abstract void updateResourceCommentCount(String resourceId, String orgId, long commentCount);
 
@@ -181,21 +184,26 @@ public abstract class BaseCommentService<C extends Comment> {
         updateResourceCommentCount(resourceId, orgId, commentCount);
     }
 
-    protected CommentResourceInfo buildTargetInfo(String owner, String clueId, String customerId, String opportunityId) {
-        if (StringUtils.isNotBlank(opportunityId)) {
-            Opportunity opportunity = opportunityMapper.selectByPrimaryKey(opportunityId);
-            if (opportunity != null) {
-                return new CommentResourceInfo(owner, opportunity.getName());
+    protected CommentResourceInfo buildTargetInfo(String followType, String owner, String clueId, String customerId, String opportunityId) {
+        if (Strings.CI.equals(followType, ModuleKey.CLUE.name())) {
+            if (StringUtils.isNotBlank(clueId)) {
+                Clue clue = clueMapper.selectByPrimaryKey(clueId);
+                if (clue != null) {
+                    return new CommentResourceInfo(owner, clue.getName());
+                }
             }
-        }
-        if (StringUtils.isNotBlank(clueId)) {
-            Clue clue = clueMapper.selectByPrimaryKey(clueId);
-            if (clue != null) {
-                return new CommentResourceInfo(owner, clue.getName());
+        } else {
+            if (StringUtils.isNotBlank(opportunityId)) {
+                Opportunity opportunity = opportunityMapper.selectByPrimaryKey(opportunityId);
+                if (opportunity != null) {
+                    return new CommentResourceInfo(owner, opportunity.getName());
+                }
             }
+
+            Customer customer = customerMapper.selectByPrimaryKey(customerId);
+            return new CommentResourceInfo(owner, customer == null ? StringUtils.EMPTY : customer.getName());
         }
-        Customer customer = customerMapper.selectByPrimaryKey(customerId);
-        return new CommentResourceInfo(owner, customer == null ? "" : customer.getName());
+        return new CommentResourceInfo(owner, StringUtils.EMPTY);
     }
 
     private C getComment(String id, String orgId) {
@@ -272,16 +280,24 @@ public abstract class BaseCommentService<C extends Comment> {
         resource.put("name", resourceInfo.name());
         resource.put("resourceId", resourceId);
         resource.put("targetType", getTargetType().name());
-        String taskType = getNotificationModule();
 
         Set<String> mentioned = new LinkedHashSet<>(mentionedUserIds);
+        List<String> noticeUsers = new ArrayList<>();
+        String event = null;
+
         if (StringUtils.isNotBlank(resourceInfo.owner()) && !mentioned.contains(resourceInfo.owner())) {
-            commonNoticeSendService.sendNotice(taskType, getCommentAddedEvent(),
-                    resource, operator, orgId, List.of(resourceInfo.owner()), true);
+            noticeUsers.add(resourceInfo.owner());
+            event = getCommentAddedEvent(resourceId);
         }
         if (!mentioned.isEmpty()) {
-            commonNoticeSendService.sendNotice(taskType, getCommentMentionedEvent(),
-                    resource, operator, orgId, new ArrayList<>(mentioned), true);
+            noticeUsers.addAll(mentioned);
+            event = getCommentMentionedEvent(resourceId);
+        }
+
+        if (event != null) {
+            MessageTask messageByEvent = extMessageTaskMapper.getMessageByEvent(event, orgId);
+            commonNoticeSendService.sendNotice(messageByEvent.getTaskType(), event,
+                    resource, operator, orgId, noticeUsers, true);
         }
     }
 

--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpPlanCommentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpPlanCommentService.java
@@ -3,6 +3,7 @@ package cn.cordys.crm.follow.service;
 import cn.cordys.aspectj.annotation.OperationLog;
 import cn.cordys.aspectj.constants.LogModule;
 import cn.cordys.aspectj.constants.LogType;
+import cn.cordys.common.constants.ModuleKey;
 import cn.cordys.common.exception.GenericException;
 import cn.cordys.common.pager.PagerWithCommentCount;
 import cn.cordys.common.util.Translator;
@@ -17,6 +18,8 @@ import cn.cordys.crm.follow.mapper.ExtFollowUpPlanMapper;
 import cn.cordys.crm.system.constants.NotificationConstants;
 import cn.cordys.mybatis.BaseMapper;
 import jakarta.annotation.Resource;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -76,18 +79,33 @@ public class FollowUpPlanCommentService extends BaseCommentService<FollowUpPlanC
     }
 
     @Override
-    protected String getNotificationModule() {
-        return NotificationConstants.Module.FOLLOW_UP_PLAN;
+    protected String getCommentAddedEvent(String resourceId) {
+        FollowUpPlan plan = planMapper.selectByPrimaryKey(resourceId);
+        if (plan != null) {
+            if (Strings.CI.equals(plan.getType(), ModuleKey.CLUE.name())) {
+                return NotificationConstants.Event.CLUE_FOLLOW_UP_PLAN_COMMENT_ADDED;
+            } else if (StringUtils.isNotBlank(plan.getOpportunityId())) {
+                return NotificationConstants.Event.OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_ADDED;
+            } else {
+                return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_PLAN_COMMENT_ADDED;
+            }
+        }
+        return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_PLAN_COMMENT_ADDED;
     }
 
     @Override
-    protected String getCommentAddedEvent() {
-        return NotificationConstants.Event.FOLLOW_UP_PLAN_COMMENT_ADDED;
-    }
-
-    @Override
-    protected String getCommentMentionedEvent() {
-        return NotificationConstants.Event.FOLLOW_UP_PLAN_COMMENT_MENTIONED;
+    protected String getCommentMentionedEvent(String resourceId) {
+        FollowUpPlan plan = planMapper.selectByPrimaryKey(resourceId);
+        if (plan != null) {
+            if (Strings.CI.equals(plan.getType(), ModuleKey.CLUE.name())) {
+                return NotificationConstants.Event.CLUE_FOLLOW_UP_PLAN_COMMENT_MENTIONED;
+            } else if (StringUtils.isNotBlank(plan.getOpportunityId())) {
+                return NotificationConstants.Event.OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_MENTIONED;
+            } else {
+                return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_PLAN_COMMENT_MENTIONED;
+            }
+        }
+        return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_PLAN_COMMENT_MENTIONED;
     }
 
     @Override
@@ -101,6 +119,6 @@ public class FollowUpPlanCommentService extends BaseCommentService<FollowUpPlanC
         if (plan == null || !Objects.equals(plan.getOrganizationId(), orgId)) {
             throw new GenericException(Translator.get("follow.comment.target_not_found"));
         }
-        return buildTargetInfo(plan.getOwner(), plan.getClueId(), plan.getCustomerId(), plan.getOpportunityId());
+        return buildTargetInfo(plan.getType(), plan.getOwner(), plan.getClueId(), plan.getCustomerId(), plan.getOpportunityId());
     }
 }

--- a/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpRecordCommentService.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/follow/service/FollowUpRecordCommentService.java
@@ -3,6 +3,7 @@ package cn.cordys.crm.follow.service;
 import cn.cordys.aspectj.annotation.OperationLog;
 import cn.cordys.aspectj.constants.LogModule;
 import cn.cordys.aspectj.constants.LogType;
+import cn.cordys.common.constants.ModuleKey;
 import cn.cordys.common.exception.GenericException;
 import cn.cordys.common.pager.PagerWithCommentCount;
 import cn.cordys.common.util.Translator;
@@ -17,6 +18,9 @@ import cn.cordys.crm.follow.mapper.ExtFollowUpRecordMapper;
 import cn.cordys.crm.system.constants.NotificationConstants;
 import cn.cordys.mybatis.BaseMapper;
 import jakarta.annotation.Resource;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -76,18 +80,33 @@ public class FollowUpRecordCommentService extends BaseCommentService<FollowUpRec
     }
 
     @Override
-    protected String getNotificationModule() {
-        return NotificationConstants.Module.FOLLOW_UP_RECORD;
+    protected String getCommentAddedEvent(String resourceId) {
+        FollowUpRecord record = recordMapper.selectByPrimaryKey(resourceId);
+        if (record != null) {
+            if (Strings.CI.equals(record.getType(), ModuleKey.CLUE.name())) {
+                return NotificationConstants.Event.CLUE_FOLLOW_UP_RECORD_COMMENT_ADDED;
+            } else if (StringUtils.isNotBlank(record.getOpportunityId())) {
+                return NotificationConstants.Event.OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_ADDED;
+            } else {
+                return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_RECORD_COMMENT_ADDED;
+            }
+        }
+        return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_RECORD_COMMENT_ADDED;
     }
 
     @Override
-    protected String getCommentAddedEvent() {
-        return NotificationConstants.Event.FOLLOW_UP_RECORD_COMMENT_ADDED;
-    }
-
-    @Override
-    protected String getCommentMentionedEvent() {
-        return NotificationConstants.Event.FOLLOW_UP_RECORD_COMMENT_MENTIONED;
+    protected String getCommentMentionedEvent(String resourceId) {
+        FollowUpRecord record = recordMapper.selectByPrimaryKey(resourceId);
+        if (record != null) {
+            if (Strings.CI.equals(record.getType(), ModuleKey.CLUE.name())) {
+                return NotificationConstants.Event.CLUE_FOLLOW_UP_RECORD_COMMENT_MENTIONED;
+            } else if (StringUtils.isNotBlank(record.getOpportunityId())) {
+                return NotificationConstants.Event.OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_MENTIONED;
+            } else {
+                return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_RECORD_COMMENT_MENTIONED;
+            }
+        }
+        return NotificationConstants.Event.CUSTOMER_FOLLOW_UP_RECORD_COMMENT_MENTIONED;
     }
 
     @Override
@@ -101,6 +120,6 @@ public class FollowUpRecordCommentService extends BaseCommentService<FollowUpRec
         if (record == null || !Objects.equals(record.getOrganizationId(), orgId)) {
             throw new GenericException(Translator.get("follow.comment.target_not_found"));
         }
-        return buildTargetInfo(record.getOwner(), record.getClueId(), record.getCustomerId(), record.getOpportunityId());
+        return buildTargetInfo(record.getType(), record.getOwner(), record.getClueId(), record.getCustomerId(), record.getOpportunityId());
     }
 }

--- a/backend/crm/src/main/java/cn/cordys/crm/system/constants/NotificationConstants.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/constants/NotificationConstants.java
@@ -170,16 +170,40 @@ public class NotificationConstants {
 		String APPROVAL_CC = "APPROVAL_CC";
 
         @Schema(description = "message.follow_up_plan_comment_added")
-        String FOLLOW_UP_PLAN_COMMENT_ADDED = "FOLLOW_UP_PLAN_COMMENT_ADDED";
+        String CLUE_FOLLOW_UP_PLAN_COMMENT_ADDED = "CLUE_FOLLOW_UP_PLAN_COMMENT_ADDED";
 
         @Schema(description = "message.follow_up_plan_comment_mentioned")
-        String FOLLOW_UP_PLAN_COMMENT_MENTIONED = "FOLLOW_UP_PLAN_COMMENT_MENTIONED";
+        String CLUE_FOLLOW_UP_PLAN_COMMENT_MENTIONED = "CLUE_FOLLOW_UP_PLAN_COMMENT_MENTIONED";
 
         @Schema(description = "message.follow_up_record_comment_added")
-        String FOLLOW_UP_RECORD_COMMENT_ADDED = "FOLLOW_UP_RECORD_COMMENT_ADDED";
+        String CLUE_FOLLOW_UP_RECORD_COMMENT_ADDED = "CLUE_FOLLOW_UP_RECORD_COMMENT_ADDED";
 
         @Schema(description = "message.follow_up_record_comment_mentioned")
-        String FOLLOW_UP_RECORD_COMMENT_MENTIONED = "FOLLOW_UP_RECORD_COMMENT_MENTIONED";
+        String CLUE_FOLLOW_UP_RECORD_COMMENT_MENTIONED = "CLUE_FOLLOW_UP_RECORD_COMMENT_MENTIONED";
+
+        @Schema(description = "message.follow_up_plan_comment_added")
+        String OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_ADDED = "OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_ADDED";
+
+        @Schema(description = "message.follow_up_plan_comment_mentioned")
+        String OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_MENTIONED = "OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_MENTIONED";
+
+        @Schema(description = "message.follow_up_record_comment_added")
+        String OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_ADDED = "OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_ADDED";
+
+        @Schema(description = "message.follow_up_record_comment_mentioned")
+        String OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_MENTIONED = "OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_MENTIONED";
+
+        @Schema(description = "message.follow_up_plan_comment_added")
+        String CUSTOMER_FOLLOW_UP_PLAN_COMMENT_ADDED = "CUSTOMER_FOLLOW_UP_PLAN_COMMENT_ADDED";
+
+        @Schema(description = "message.follow_up_plan_comment_mentioned")
+        String CUSTOMER_FOLLOW_UP_PLAN_COMMENT_MENTIONED = "CUSTOMER_FOLLOW_UP_PLAN_COMMENT_MENTIONED";
+
+        @Schema(description = "message.follow_up_record_comment_added")
+        String CUSTOMER_FOLLOW_UP_RECORD_COMMENT_ADDED = "CUSTOMER_FOLLOW_UP_RECORD_COMMENT_ADDED";
+
+        @Schema(description = "message.follow_up_record_comment_mentioned")
+        String CUSTOMER_FOLLOW_UP_RECORD_COMMENT_MENTIONED = "CUSTOMER_FOLLOW_UP_RECORD_COMMENT_MENTIONED";
     }
 
     public interface RelatedUser {
@@ -334,16 +358,40 @@ public class NotificationConstants {
 		String APPROVAL_CC_TEXT = "APPROVAL_CC_TEXT";
 
         @Schema(description = "message.follow_up_plan_comment_added_text")
-        String FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT = "FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT";
+        String CLUE_FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT = "CLUE_FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT";
 
         @Schema(description = "message.follow_up_plan_comment_mentioned_text")
-        String FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT = "FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT";
+        String CLUE_FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT = "CLUE_FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT";
 
         @Schema(description = "message.follow_up_record_comment_added_text")
-        String FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT = "FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT";
+        String CLUE_FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT = "CLUE_FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT";
 
         @Schema(description = "message.follow_up_record_comment_mentioned_text")
-        String FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT = "FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT";
+        String CLUE_FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT = "CLUE_FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT";
+
+        @Schema(description = "message.follow_up_plan_comment_added_text")
+        String OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT = "OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT";
+
+        @Schema(description = "message.follow_up_plan_comment_mentioned_text")
+        String OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT = "OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT";
+
+        @Schema(description = "message.follow_up_record_comment_added_text")
+        String OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT = "OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT";
+
+        @Schema(description = "message.follow_up_record_comment_mentioned_text")
+        String OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT = "OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT";
+
+        @Schema(description = "message.follow_up_plan_comment_added_text")
+        String CUSTOMER_FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT = "CUSTOMER_FOLLOW_UP_PLAN_COMMENT_ADDED_TEXT";
+
+        @Schema(description = "message.follow_up_plan_comment_mentioned_text")
+        String CUSTOMER_FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT = "CUSTOMER_FOLLOW_UP_PLAN_COMMENT_MENTIONED_TEXT";
+
+        @Schema(description = "message.follow_up_record_comment_added_text")
+        String CUSTOMER_FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT = "CUSTOMER_FOLLOW_UP_RECORD_COMMENT_ADDED_TEXT";
+
+        @Schema(description = "message.follow_up_record_comment_mentioned_text")
+        String CUSTOMER_FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT = "CUSTOMER_FOLLOW_UP_RECORD_COMMENT_MENTIONED_TEXT";
     }
 
 

--- a/backend/crm/src/main/java/cn/cordys/crm/system/mapper/ExtMessageTaskMapper.java
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/mapper/ExtMessageTaskMapper.java
@@ -14,6 +14,8 @@ public interface ExtMessageTaskMapper {
 
     MessageTask getMessageByModuleAndEvent(@Param("module") String taskType, @Param("event") String event, @Param("organizationId") String organizationId);
 
+    MessageTask getMessageByEvent(@Param("event") String event, @Param("organizationId") String organizationId);
+
     void updateMessageTask(@Param("request") MessageTaskBatchRequest messageTaskBatchRequest, @Param("organizationId") String organizationId);
 
 }

--- a/backend/crm/src/main/java/cn/cordys/crm/system/mapper/ExtMessageTaskMapper.xml
+++ b/backend/crm/src/main/java/cn/cordys/crm/system/mapper/ExtMessageTaskMapper.xml
@@ -35,5 +35,8 @@
         select * from sys_message_task where organization_id = #{organizationId} and task_type = #{module} and event = #{event} limit 1;
     </select>
 
+    <select id="getMessageByEvent" resultType="cn.cordys.crm.system.domain.MessageTask">
+        select * from sys_message_task where organization_id = #{organizationId} and event = #{event} limit 1;
+    </select>
 
 </mapper> 

--- a/backend/crm/src/main/resources/migration/1.9.0/dml/V1.9.0_2_1__data.sql
+++ b/backend/crm/src/main/resources/migration/1.9.0/dml/V1.9.0_2_1__data.sql
@@ -12,10 +12,20 @@ VALUES
 INSERT INTO sys_message_task
 (id, event, task_type, email_enable, sys_enable, organization_id, template, create_user, create_time, update_user, update_time)
 VALUES
-    (UUID_SHORT(), 'FOLLOW_UP_PLAN_COMMENT_ADDED', 'FOLLOW_UP_PLAN', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
-    (UUID_SHORT(), 'FOLLOW_UP_PLAN_COMMENT_MENTIONED', 'FOLLOW_UP_PLAN', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
-    (UUID_SHORT(), 'FOLLOW_UP_RECORD_COMMENT_ADDED', 'FOLLOW_UP_RECORD', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
-    (UUID_SHORT(), 'FOLLOW_UP_RECORD_COMMENT_MENTIONED', 'FOLLOW_UP_RECORD', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2);
+    (UUID_SHORT(), 'CUSTOMER_FOLLOW_UP_PLAN_COMMENT_ADDED', 'CUSTOMER', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'CUSTOMER_FOLLOW_UP_PLAN_COMMENT_MENTIONED', 'CUSTOMER', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'CUSTOMER_FOLLOW_UP_RECORD_COMMENT_ADDED', 'CUSTOMER', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'CUSTOMER_FOLLOW_UP_RECORD_COMMENT_MENTIONED', 'CUSTOMER', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+
+    (UUID_SHORT(), 'CLUE_FOLLOW_UP_PLAN_COMMENT_ADDED', 'CLUE', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'CLUE_FOLLOW_UP_PLAN_COMMENT_MENTIONED', 'CLUE', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'CLUE_FOLLOW_UP_RECORD_COMMENT_ADDED', 'CLUE', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'CLUE_FOLLOW_UP_RECORD_COMMENT_MENTIONED', 'CLUE', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+
+    (UUID_SHORT(), 'OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_ADDED', 'OPPORTUNITY', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'OPPORTUNITY_FOLLOW_UP_PLAN_COMMENT_MENTIONED', 'OPPORTUNITY', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_ADDED', 'OPPORTUNITY', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2),
+    (UUID_SHORT(), 'OPPORTUNITY_FOLLOW_UP_RECORD_COMMENT_MENTIONED', 'OPPORTUNITY', false, true, '100001', null, 'admin', UNIX_TIMESTAMP() * 1000 + 2, 'admin', UNIX_TIMESTAMP() * 1000 + 2);
 
 
 SET SESSION innodb_lock_wait_timeout = DEFAULT;


### PR DESCRIPTION
fix: follow up record and plan comment notice classify  --bug=1073872@tapd-34675357 --user=陈建星 【跟进计录/计划】评论提醒类通知未归类到对应业务模块tab，"全部消息"可见但分类tab下查不到 https://www.tapd.cn/34675357/s/2019436 