### PR TITLE
fix: comment reply display

### DIFF
--- a/frontend/packages/web/src/components/business/crm-comment/components/commentItem.vue
+++ b/frontend/packages/web/src/components/business/crm-comment/components/commentItem.vue
@@ -27,14 +27,10 @@
       />
 
       <div v-else class="crm-comment-item__content">
-        <div class="flex items-center">
-          <template v-if="props.comment.replyToUserName">
-            <div class="text-[var(--text-n4)]">{{ t('crmComment.replyTo') }} {{ props.comment.replyToUserName }}：</div>
-          </template>
-          <div class="text-[var(--text-n1)]">
-            {{ props.comment.content }}
-          </div>
-        </div>
+        <span v-if="props.comment.replyToUserName" class="text-[var(--text-n4)]">
+          {{ t('crmComment.replyTo') }} {{ props.comment.replyToUserName }}：
+        </span>
+        <span class="text-[var(--text-n1)]">{{ props.comment.content }}</span>
       </div>
 
       <div v-if="!isEditing" class="mt-[8px] flex justify-end gap-[8px]">


### PR DESCRIPTION
【【跟进记录/计划】回复内容为长文本时，"回复XX"标识与正文内容混排，展示样式错乱】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001074050