### PR TITLE
fix: mobile comment selected user locale

### DIFF
--- a/frontend/packages/mobile/src/components/business/crm-comment/locale/en-US.ts
+++ b/frontend/packages/mobile/src/components/business/crm-comment/locale/en-US.ts
@@ -12,5 +12,5 @@ export default {
   'crmComment.moreReplies': 'More replies ({count})',
   'crmComment.collapseReplies': 'Collapse',
   'crmComment.submit': 'Send',
-  'crmComment.disabledUser': 'Quit',
+  'crmComment.disabledUser': 'Disabled',
 };

--- a/frontend/packages/mobile/src/components/business/crm-comment/locale/zh-CN.ts
+++ b/frontend/packages/mobile/src/components/business/crm-comment/locale/zh-CN.ts
@@ -12,5 +12,5 @@ export default {
   'crmComment.moreReplies': '更多回复（{count}）',
   'crmComment.collapseReplies': '收起',
   'crmComment.submit': '发送',
-  'crmComment.disabledUser': '离职',
+  'crmComment.disabledUser': '已禁用',
 };


### PR DESCRIPTION
【【移动端】评论 — @人员列表中，已禁用账号的状态标签显示为"离职"，与PC端"已禁用"不一致】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001074047