### PR TITLE
fix: term setting column disabled

### DIFF
--- a/frontend/packages/web/src/views/system/business/components/termSettings/index.vue
+++ b/frontend/packages/web/src/views/system/business/components/termSettings/index.vue
@@ -223,6 +223,8 @@
       title: t('system.business.term.standardTerm'),
       key: 'standardTerm',
       width: 160,
+      columnSelectorDisabled: true,
+      fixed: 'left',
       ellipsis: {
         tooltip: true,
       },


### PR DESCRIPTION
【【术语设置】表头显示设置中，"标准术语"列可被关闭、可调整顺序，与预期规则不符】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001074379