### PR TITLE
fix: term auto discovery

### DIFF
--- a/frontend/packages/web/src/views/system/business/components/termSettings/components/termDiscoveryDrawer.vue
+++ b/frontend/packages/web/src/views/system/business/components/termSettings/components/termDiscoveryDrawer.vue
@@ -82,6 +82,7 @@
       ellipsis: {
         tooltip: true,
       },
+      render: (row) => (row.source === 'USER_CHAT' ? t('system.business.term.discoverySourceUserDialogue') : '-'),
     },
     {
       title: t('system.business.term.discoveryTime'),

--- a/frontend/packages/web/src/views/system/business/locale/en-US.ts
+++ b/frontend/packages/web/src/views/system/business/locale/en-US.ts
@@ -97,6 +97,7 @@ export default {
   'system.business.term.aiDiscovery': 'AI Discovery',
   'system.business.term.undefinedTerm': 'Undefined Term',
   'system.business.term.discoverySource': 'Source',
+  'system.business.term.discoverySourceUserDialogue': 'User Dialogue',
   'system.business.term.discoveryTime': 'Discovery Time',
   'system.business.term.suggestedMapping': 'Suggested Mapping',
   'system.business.term.adopt': 'Adopt',

--- a/frontend/packages/web/src/views/system/business/locale/zh-CN.ts
+++ b/frontend/packages/web/src/views/system/business/locale/zh-CN.ts
@@ -96,6 +96,7 @@ export default {
   'system.business.term.aiDiscovery': 'AI 自动发现',
   'system.business.term.undefinedTerm': '未定义术语',
   'system.business.term.discoverySource': '发现来源',
+  'system.business.term.discoverySourceUserDialogue': '用户对话',
   'system.business.term.discoveryTime': '发现时间',
   'system.business.term.suggestedMapping': '建议映射',
   'system.business.term.adopt': '采纳',


### PR DESCRIPTION
【【术语设置】AI 自动发现列表中对应的字段“发现来源”未正确回显为中文】
https://www.tapd.cn/tapd_fe/34675357/bug/detail/1134675357001075154